### PR TITLE
infra: delete-removed 옵션 true로 추가

### DIFF
--- a/.github/workflows/Dev-CD.yml
+++ b/.github/workflows/Dev-CD.yml
@@ -28,3 +28,4 @@ jobs:
           bucket: ${{ secrets.DEV_S3_BUCKET_NAME }}
           bucket-region: ${{ secrets.AWS_DEFAULT_REGION }}
           dist-id: ${{ secrets.DEV_CLOUDFRONT_ID }}
+          delete-removed: true


### PR DESCRIPTION
## 개요

- CD workflow 상에서 S3로 올리는 과정 중, `delete-removed` 옵션을 `true`로 추가했습니다.
  - `delete-removed`: Removes files in S3, that are not available in the local copy of the directory
  - S3에 올라가있지만, Github Repository(local)에서는 제거된 파일을 S3에서도 제거하는 옵션.. 으로 이해했습니다!
  - 그래서 켰습니다.

<br class="Apple-interchange-newline">

<br>

## 작업 사항

- CD workflow에 `delete-removed` 옵션을 `true`로 추가

<br>

## 참고 사항 (optional)

- 서영님이 알려주셨습니다!
  [참고 링크](https://github.com/8-Sprinters/ListyWave-front/pull/6#discussion_r1468359462)

<br>

## 관련 이슈 (optional)

- #6 

<br>

## 스크린샷

<br>

## 리뷰어에게


<br>
