### PR TITLE
Feat: 마이리스트, 콜라보리스트 페이지 전체 리스트 조회 무한스크롤 구현

### DIFF
--- a/src/app/_api/list/getAllList.ts
+++ b/src/app/_api/list/getAllList.ts
@@ -1,10 +1,18 @@
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { AllListType } from '@/lib/types/listType';
 
-export async function getAllList(userId: number, type: string, category?: string, cursorId?: any) {
-  const query = `${category ? `${category}` : 'entire'} ${cursorId ? `&cursorId=${cursorId}` : ''}`;
+export async function getAllList(userId: number, type: string, category: string, cursorId?: number) {
+  const params = new URLSearchParams({
+    type,
+    category,
+    size: '5',
+  });
 
-  const response = await axiosInstance.get<AllListType>(`/users/${userId}/lists?type=${type}&category=${query}&size=5`);
+  if (cursorId) {
+    params.append('cursorId', cursorId.toString());
+  }
+
+  const response = await axiosInstance.get<AllListType>(`/users/${userId}/lists?${params.toString()}`);
 
   return response.data;
 }

--- a/src/app/_api/list/getAllList.ts
+++ b/src/app/_api/list/getAllList.ts
@@ -1,12 +1,10 @@
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { AllListType } from '@/lib/types/listType';
 
-export async function getAllList(userId: number, type: string, category?: string) {
-  const query = `${category ? `${category}` : 'entire'}`;
+export async function getAllList(userId: number, type: string, category?: string, cursorId?: any) {
+  const query = `${category ? `${category}` : 'entire'} ${cursorId ? `&cursorId=${cursorId}` : ''}`;
 
-  const response = await axiosInstance.get<AllListType>(
-    `/users/${userId}/lists?type=${type}&category=${query}&size=10`
-  );
+  const response = await axiosInstance.get<AllListType>(`/users/${userId}/lists?type=${type}&category=${query}&size=5`);
 
   return response.data;
 }

--- a/src/app/user/[userId]/_components/Card.css.ts
+++ b/src/app/user/[userId]/_components/Card.css.ts
@@ -1,4 +1,5 @@
 import { style, createVar } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
 
 export const listColor = createVar();
 
@@ -9,6 +10,7 @@ export const container = style({
 
   borderRadius: '1.5rem',
   backgroundColor: listColor,
+  border: `1px solid ${vars.color.gray5}`,
 });
 
 export const title = style({
@@ -16,7 +18,7 @@ export const title = style({
 
   fontSize: '1.7rem',
   fontWeight: '600',
-  color: 'var(--text-text-grey-dark, #202020)',
+  color: vars.color.black,
   textAlign: 'right',
   letterSpacing: '-0.51px',
   wordBreak: 'keep-all',
@@ -28,7 +30,7 @@ export const list = style({
 
   fontSize: '1.2rem',
   fontWeight: '400',
-  color: 'var(--text-text-grey-dark, #202020)',
+  color: vars.color.black,
   lineHeight: '2.5rem',
   letterSpacing: '-0.36px',
 });
@@ -46,7 +48,7 @@ export const lockText = style({
   fontSize: '1.1rem',
   fontWeight: '400',
   letterSpacing: '-0.33px',
-  color: '#AFB1B6',
+  color: vars.color.gray7,
 });
 
 export const item = style({

--- a/src/app/user/[userId]/_components/Card.css.ts
+++ b/src/app/user/[userId]/_components/Card.css.ts
@@ -60,3 +60,9 @@ export const item = style({
 export const rank = style({
   width: '1.2rem',
 });
+
+export const itemTitle = style({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});

--- a/src/app/user/[userId]/_components/Card.tsx
+++ b/src/app/user/[userId]/_components/Card.tsx
@@ -39,7 +39,7 @@ export default function Card({ list, isOwner }: CardProps) {
               {item.ranking}
               {'.'}
             </span>
-            <span>{item.title}</span>
+            <span className={styles.itemTitle}>{item.title}</span>
           </li>
         ))}
       </ul>

--- a/src/app/user/[userId]/_components/Categories.css.ts
+++ b/src/app/user/[userId]/_components/Categories.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
 
 export const container = style({
   padding: '2.1rem 0 1.5rem 1.5rem',
@@ -17,19 +18,20 @@ export const container = style({
 export const button = style({
   padding: '0.8rem 1.2rem',
 
-  backgroundColor: '#FFF',
+  backgroundColor: vars.color.white,
   borderRadius: '5rem',
-  border: '1px solid #DEDEDE',
+  border: `1px solid ${vars.color.gray5}`,
 
+  /** TODO - 공용폰트 body large 적용 */
   fontSize: '1.6rem',
-  fontWeight: '500',
-  color: '#828282',
+  fontWeight: '400',
+  color: vars.color.gray9,
   letterSpacing: '-0.48px',
   whiteSpace: 'nowrap',
 });
 
 export const variant = style({
-  backgroundColor: '#0047FF',
-  color: '#FFF',
+  backgroundColor: vars.color.blue,
+  color: vars.color.white,
   border: 'none',
 });

--- a/src/app/user/[userId]/_components/Categories.tsx
+++ b/src/app/user/[userId]/_components/Categories.tsx
@@ -18,8 +18,6 @@ interface CategoriesProps {
   selectedCategory: string;
 }
 
-export const DEFAULT_CATEGORY = 'entire';
-
 export default function Categories({ handleFetchListsOnCategory, selectedCategory }: CategoriesProps) {
   const { data } = useQuery<CategoryType[]>({
     queryKey: [QUERY_KEYS.getCategories],

--- a/src/app/user/[userId]/_components/Categories.tsx
+++ b/src/app/user/[userId]/_components/Categories.tsx
@@ -5,7 +5,6 @@
  - [ ] 클릭했을때 로직 (상위요소에 핸들러 고민) (리팩토링)
  */
 
-import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import * as styles from './Categories.css';
@@ -16,13 +15,12 @@ import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 
 interface CategoriesProps {
   handleFetchListsOnCategory: (category: string) => void;
+  selectedCategory: string;
 }
 
 export const DEFAULT_CATEGORY = 'entire';
 
-export default function Categories({ handleFetchListsOnCategory }: CategoriesProps) {
-  const [selected, setSelected] = useState(DEFAULT_CATEGORY);
-
+export default function Categories({ handleFetchListsOnCategory, selectedCategory }: CategoriesProps) {
   const { data } = useQuery<CategoryType[]>({
     queryKey: [QUERY_KEYS.getCategories],
     queryFn: getCategories,
@@ -30,7 +28,6 @@ export default function Categories({ handleFetchListsOnCategory }: CategoriesPro
 
   const handleChangeCategory = (category: string) => () => {
     handleFetchListsOnCategory(category);
-    setSelected(category);
   };
 
   return (
@@ -39,7 +36,7 @@ export default function Categories({ handleFetchListsOnCategory }: CategoriesPro
         <button
           key={category.codeValue}
           onClick={handleChangeCategory(category.nameValue)}
-          className={`${styles.button} ${category.nameValue === selected ? styles.variant : ''}`}
+          className={`${styles.button} ${category.nameValue === selectedCategory ? styles.variant : ''}`}
         >
           {category.korNameValue}
         </button>

--- a/src/app/user/[userId]/_components/Content.css.ts
+++ b/src/app/user/[userId]/_components/Content.css.ts
@@ -69,3 +69,7 @@ export const variantLine = styleVariants({
     },
   ],
 });
+
+export const target = style({
+  height: '1px',
+});

--- a/src/app/user/[userId]/_components/Content.css.ts
+++ b/src/app/user/[userId]/_components/Content.css.ts
@@ -1,4 +1,5 @@
 import { style, styleVariants } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
 
 export const container = style({
   width: '100%',
@@ -7,7 +8,7 @@ export const container = style({
   position: 'absolute',
   top: 0,
 
-  backgroundColor: '#FFF',
+  backgroundColor: vars.color.white,
   borderTopLeftRadius: '2.5rem',
   borderTopRightRadius: '2.5rem',
 });
@@ -27,10 +28,11 @@ export const button = style({
   width: '100%',
   height: '100%',
 
-  backgroundColor: 'white',
+  backgroundColor: vars.color.white,
   borderTop: '1px solid rgba(0, 0, 0, 0.25)',
   borderBottom: '1px solid rgba(0, 0, 0, 0.10)',
 
+  /** TODO - 공용폰트 body large 적용 */
   fontSize: '1.6rem',
   fontWeight: '500',
 });

--- a/src/app/user/[userId]/_components/Content.tsx
+++ b/src/app/user/[userId]/_components/Content.tsx
@@ -51,7 +51,7 @@ export default function Content({ userId, type }: ContentProps) {
   } = useInfiniteQuery<AllListType>({
     queryKey: [QUERY_KEYS.getAllList, userId, type, selectedCategory],
     queryFn: ({ pageParam: cursorId }) => {
-      return getAllList(userId, type, selectedCategory, cursorId);
+      return getAllList(userId, type, selectedCategory, cursorId as number);
     },
     initialPageParam: null,
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.cursorId : null),

--- a/src/app/user/[userId]/_components/Content.tsx
+++ b/src/app/user/[userId]/_components/Content.tsx
@@ -2,7 +2,6 @@
 
 /**
  TODO
- - [x] 무한스크롤 적용
  - [ ] 피드페이지 스켈레톤 ui 적용
  */
 
@@ -61,15 +60,11 @@ export default function Content({ userId, type }: ContentProps) {
     return listsData ? listsData.pages.flatMap(({ feedLists }) => feedLists) : [];
   }, [listsData]);
 
-  // console.log(hasNextPage); // 삭제 예정
-
   const ref = useIntersectionObserver(() => {
     if (hasNextPage) {
       fetchNextPage();
     }
   });
-
-  console.log(lists); // 삭제 예정
 
   const handleFetchListsOnCategory = (category: string) => {
     setSelectedCategory(category);

--- a/src/app/user/[userId]/_components/Content.tsx
+++ b/src/app/user/[userId]/_components/Content.tsx
@@ -7,7 +7,7 @@
  */
 
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import { MasonryGrid } from '@egjs/react-grid';
 
@@ -75,10 +75,19 @@ export default function Content({ userId, type }: ContentProps) {
     setSelectedCategory(category);
 
     queryClient.resetQueries({
-      queryKey: [QUERY_KEYS.getAllList, userId, type, category],
+      queryKey: [QUERY_KEYS.getAllList, userId, type, selectedCategory],
       exact: true,
     });
   };
+
+  useEffect(() => {
+    return () => {
+      queryClient.removeQueries({
+        queryKey: [QUERY_KEYS.getAllList, userId, type, selectedCategory],
+        exact: true,
+      });
+    };
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/src/app/user/[userId]/_components/FollowButton.css.ts
+++ b/src/app/user/[userId]/_components/FollowButton.css.ts
@@ -1,12 +1,13 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
 
 export const button = style({
   padding: '0.8rem 1.2rem',
 
-  backgroundColor: 'var(--Blue, #0047FF)',
+  backgroundColor: vars.color.blue,
   borderRadius: '5rem',
 
   fontSize: '1rem',
   fontWeight: '600',
-  color: '#fff',
+  color: vars.color.white,
 });

--- a/src/app/user/[userId]/_components/Profile.css.ts
+++ b/src/app/user/[userId]/_components/Profile.css.ts
@@ -1,4 +1,5 @@
 import { style, createVar } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
 
 export const imageUrl = createVar();
 
@@ -48,7 +49,7 @@ export const profileImage = style({
   height: '5rem',
 
   borderRadius: '50%',
-  border: '2px solid #FFF',
+  border: `2px solid ${vars.color.white}`,
 });
 
 export const info = style({
@@ -66,7 +67,7 @@ export const user = style({
 export const nickName = style({
   fontSize: '2rem',
   fontWeight: ' 700',
-  color: '#202020',
+  color: vars.color.black,
   letterSpacing: '-0.6px',
 });
 
@@ -99,7 +100,7 @@ export const description = style({
 
   fontSize: '1.2rem',
   fontWeight: '500',
-  color: '#333',
+  color: vars.color.black,
   lineHeight: '1.6rem',
   letterSpacing: '-0.36px',
 });

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Observer API를 사용하여 요소를 감지하는 커스텀 hook 입니다.
+ * 무한스크롤에서 사용할 수 있습니다.
+ *
+ * @param {function} callback intersection이 발생했을 때 호툴되는 콜백함수
+ * @returns target 요소에 전달할 ref 값
+ */
+
+const options = {
+  root: null,
+  rootMain: '0px',
+  threshold: 1, // 단계별 콜백함수 호출
+};
+
+const useIntersectionObserver = (callback: (entry: IntersectionObserverEntry) => void) => {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        callback(entries[0]);
+      }
+    }, options);
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    // clean up
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, callback]);
+
+  return ref;
+};
+
+export default useIntersectionObserver;


### PR DESCRIPTION
## 개요

- 마이리스트, 콜라보리스트 페이지 전체 리스트 무한스크롤을 구현했습니다.

<br>

## 작업 사항

- react-query를 사용한 리스트 목록조회 무한스크롤 기능
- scroll 감지 observer api 커스텀 훅 생성 (useIntersectionObserver)
- 페이지 관련 컴포넌트 스타일 색상 공용 컬러 변수로 변경
- 기타 일부 스타일 수정

<br>

## 참고 사항 (optional)

- 리스트 페이지 추가 작업 예정 목록입니다. 참고 부탁드립니다.
  - [ ] 팔로우/팔로잉 기능
  - [ ] UI 최종 점검(스켈레톤 UI 추가, 공용 테마 적용 등)
  - [ ] 로그인 여부에 따른 로직 수정

<br>

## 스크린샷

![Feb-11-2024 15-41-10](https://github.com/8-Sprinters/ListyWave-front/assets/124856726/ba7e98ce-b13c-44b1-9f92-89975f99cbd2)

<br>

## 리뷰어에게

- 현재 한번에 불러오는 리스트 개수(size)를 5개로 설정해 놓았는데, QA 테스트 후 size 변경 가능성도 있습니다.
- observer api 커스텀 훅 사용하시다가 수정이 필요한 부분 있으시면 말씀 부탁드립니다.

<br>
