### PR TITLE
Feat: 마이리스트, 콜라보리스트 페이지 팔로우 기능 구현

### DIFF
--- a/src/app/[userNickname]/[listId]/_components/ListDetailInner/Footer.tsx
+++ b/src/app/[userNickname]/[listId]/_components/ListDetailInner/Footer.tsx
@@ -12,7 +12,8 @@ import * as styles from './Footer.css';
 import CollectIcon from '/public/icons/collect.svg';
 import ShareIcon from '/public/icons/share.svg';
 import EtcIcon from '/public/icons/etc.svg';
-import { CollaboratorType, ListItemsType } from '@/lib/types/listType';
+import { ItemType } from '@/lib/types/listType';
+import { UserProfileType } from '@/lib/types/userProfileType';
 
 interface BottomSheetOptionsProps {
   key: string;
@@ -29,8 +30,8 @@ interface FooterProps {
   listId: string;
   title: string;
   description: string;
-  items: ListItemsType[];
-  collaborators: CollaboratorType[];
+  items: ItemType[];
+  collaborators: UserProfileType[];
   ownerNickname: string;
 }
 

--- a/src/app/_api/follow/createFollowUser.ts
+++ b/src/app/_api/follow/createFollowUser.ts
@@ -1,0 +1,5 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+
+export default async function createFollowUser(userId: number) {
+  return await axiosInstance.post(`/follow/${userId}`);
+}

--- a/src/app/_api/follow/createFollowUser.ts
+++ b/src/app/_api/follow/createFollowUser.ts
@@ -1,5 +1,7 @@
 import axiosInstance from '@/lib/axios/axiosInstance';
 
-export default async function createFollowUser(userId: number) {
+const createFollowUser = async (userId: number) => {
   return await axiosInstance.post(`/follow/${userId}`);
-}
+};
+
+export default createFollowUser;

--- a/src/app/_api/follow/deleteFollowUser.ts
+++ b/src/app/_api/follow/deleteFollowUser.ts
@@ -1,0 +1,5 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+
+export default async function deleteFollowUser(userId: number) {
+  return await axiosInstance.delete(`/follow/${userId}`);
+}

--- a/src/app/_api/follow/deleteFollowUser.ts
+++ b/src/app/_api/follow/deleteFollowUser.ts
@@ -1,5 +1,7 @@
 import axiosInstance from '@/lib/axios/axiosInstance';
 
-export default async function deleteFollowUser(userId: number) {
+const deleteFollowUser = async (userId: number) => {
   return await axiosInstance.delete(`/follow/${userId}`);
-}
+};
+
+export default deleteFollowUser;

--- a/src/app/_api/list/getAllList.ts
+++ b/src/app/_api/list/getAllList.ts
@@ -1,7 +1,7 @@
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { AllListType } from '@/lib/types/listType';
 
-export async function getAllList(userId: number, type: string, category: string, cursorId?: number) {
+const getAllList = async (userId: number, type: string, category: string, cursorId?: number) => {
   const params = new URLSearchParams({
     type,
     category,
@@ -13,6 +13,7 @@ export async function getAllList(userId: number, type: string, category: string,
   }
 
   const response = await axiosInstance.get<AllListType>(`/users/${userId}/lists?${params.toString()}`);
-
   return response.data;
-}
+};
+
+export default getAllList;

--- a/src/app/_api/user/getUserOne.ts
+++ b/src/app/_api/user/getUserOne.ts
@@ -1,8 +1,10 @@
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { UserType } from '@/lib/types/userProfileType';
 
-export const getUserOne = async (userId: number) => {
+const getUserOne = async (userId: number) => {
   const response = await axiosInstance.get<UserType>(`/users/${userId}`);
 
   return response.data;
 };
+
+export default getUserOne;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,7 @@ export default function TempLayout({ children }: { children: ReactNode }) {
         <QueryClientProvider client={queryClient}>
           <div id="modal-root" />
           <div>{children}</div>
+          <ToastContainer />
         </QueryClientProvider>
       </body>
     </html>

--- a/src/app/user/[userId]/_components/Card.tsx
+++ b/src/app/user/[userId]/_components/Card.tsx
@@ -36,7 +36,7 @@ export default function Card({ list, isOwner }: CardProps) {
         {list.listItems.map((item) => (
           <li key={item.id} className={styles.item}>
             <span className={styles.rank}>
-              {item.ranking}
+              {item.rank}
               {'.'}
             </span>
             <span className={styles.itemTitle}>{item.title}</span>

--- a/src/app/user/[userId]/_components/Content.tsx
+++ b/src/app/user/[userId]/_components/Content.tsx
@@ -17,8 +17,8 @@ import BlueLineLongIcon from '/public/icons/blue_line_long.svg';
 import Card from './Card';
 import Categories from './Categories';
 
-import { getUserOne } from '@/app/_api/user/getUserOne';
-import { getAllList } from '@/app/_api/list/getAllList';
+import getUserOne from '@/app/_api/user/getUserOne';
+import getAllList from '@/app/_api/list/getAllList';
 
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { UserType } from '@/lib/types/userProfileType';

--- a/src/app/user/[userId]/_components/FollowButton.css.ts
+++ b/src/app/user/[userId]/_components/FollowButton.css.ts
@@ -1,13 +1,26 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 
 export const button = style({
   padding: '0.8rem 1.2rem',
-
-  backgroundColor: vars.color.blue,
   borderRadius: '5rem',
+  fontWeight: '400',
+  lineHeight: '1.6rem',
+});
 
-  fontSize: '1rem',
-  fontWeight: '600',
-  color: vars.color.white,
+export const variant = styleVariants({
+  primary: [
+    button,
+    {
+      backgroundColor: vars.color.blue,
+      color: vars.color.white,
+    },
+  ],
+  gray: [
+    button,
+    {
+      backgroundColor: vars.color.gray7,
+      color: vars.color.white,
+    },
+  ],
 });

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -4,7 +4,7 @@
  TODO
  - [x] 상태(팔로우, 언팔로우)에 따른 팔로우 버튼 UI
  - [x] 조건(비회원, 회원)에 따른 팔로우 버튼 동작(api 연동)
- - [ ] 팔로우 취소 api 연동
+ - [x] 팔로우 취소 api 연동
  - [ ] 최대 1,000명까지 팔로우 제한 - 토스트 에러
  */
 
@@ -15,6 +15,7 @@ import { AxiosError } from 'axios';
 import * as styles from './FollowButton.css';
 
 import createFollowUser from '@/app/_api/follow/createFollowUser';
+import deleteFollowUser from '@/app/_api/follow/deleteFollowUser';
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 
 interface FollowButtonProps {
@@ -42,12 +43,31 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
     },
   });
 
-  const handleFollowUser = () => {
-    followUser.mutate();
+  const deleteFollowingUser = useMutation({
+    mutationKey: [QUERY_KEYS.deleteFollow, userId],
+    mutationFn: () => deleteFollowUser(userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.userOne, userId],
+      });
+    },
+  });
+
+  const handleFollowUser = (isFollowed: boolean) => () => {
+    if (isFollowed) {
+      // 이미 팔로잉 상태이므로 팔로우 취소
+      deleteFollowingUser.mutate();
+    } else {
+      // 팔로우 하기
+      followUser.mutate();
+    }
   };
 
   return (
-    <button className={`${isFollowed ? styles.variant.gray : styles.variant.primary}`} onClick={handleFollowUser}>
+    <button
+      className={`${isFollowed ? styles.variant.gray : styles.variant.primary}`}
+      onClick={handleFollowUser(isFollowed)}
+    >
       {isFollowed ? '팔로우 취소' : '팔로우'}
     </button>
   );

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -5,27 +5,43 @@
  - [x] 상태(팔로우, 언팔로우)에 따른 팔로우 버튼 UI
  - [x] 조건(비회원, 회원)에 따른 팔로우 버튼 동작(api 연동)
  - [x] 팔로우 취소 api 연동
- - [ ] 최대 1,000명까지 팔로우 제한 - 토스트 에러
+ - [x] 최대 1,000명까지 팔로우 제한 - 토스트 에러
  */
 
 import { useRouter } from 'next/navigation';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import * as styles from './FollowButton.css';
 
 import createFollowUser from '@/app/_api/follow/createFollowUser';
 import deleteFollowUser from '@/app/_api/follow/deleteFollowUser';
+import getUserOne from '@/app/_api/user/getUserOne';
+
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+import { UserType } from '@/lib/types/userProfileType';
+import { useUser } from '@/store/useUser';
+// import toasting from '@/lib/utils/toasting'; // 나중에 사용얘정 토스트
 
 interface FollowButtonProps {
   userId: number;
   isFollowed: boolean;
 }
 
+const MAX_FOLLOWING = 1000;
+
 export default function FollowButton({ isFollowed, userId }: FollowButtonProps) {
   const queryClient = useQueryClient();
   const router = useRouter();
+  const { user: userMe } = useUser();
+
+  // 내 정보 조회
+  const { data: userMeData } = useQuery<UserType>({
+    queryKey: [QUERY_KEYS.userOne, userMe.id],
+    queryFn: () => getUserOne(userMe.id),
+  });
+
+  console.log(userMeData); // 삭제 예정
 
   const followUser = useMutation({
     mutationKey: [QUERY_KEYS.follow, userId],
@@ -54,6 +70,13 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
   });
 
   const handleFollowUser = (isFollowed: boolean) => () => {
+    // 만약, 내가 팔로우한 사람이 이미 최대인 경우(1천명) 팔로우 요청 할 수 없음
+    if (userMeData && userMeData?.followingCount >= MAX_FOLLOWING) {
+      // TODO 토스트 메세지 적용이 안되서 우선 주석처리 해둠
+      // toasting({ type: 'warning', txt: '최대 1000명까지 팔로우할 수 있어요.' });
+      return;
+    }
+
     if (isFollowed) {
       // 이미 팔로잉 상태이므로 팔로우 취소
       deleteFollowingUser.mutate();

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -1,13 +1,5 @@
 'use client';
 
-/**
- TODO
- - [x] 상태(팔로우, 언팔로우)에 따른 팔로우 버튼 UI
- - [x] 조건(비회원, 회원)에 따른 팔로우 버튼 동작(api 연동)
- - [x] 팔로우 취소 api 연동
- - [x] 최대 1,000명까지 팔로우 제한 - 토스트 에러
- */
-
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
@@ -35,13 +27,10 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
   const router = useRouter();
   const { user: userMe } = useUser();
 
-  // 내 정보 조회
   const { data: userMeData } = useQuery<UserType>({
     queryKey: [QUERY_KEYS.userOne, userMe.id],
     queryFn: () => getUserOne(userMe.id),
   });
-
-  console.log(userMeData); // 삭제 예정
 
   const followUser = useMutation({
     mutationKey: [QUERY_KEYS.follow, userId],
@@ -70,18 +59,15 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
   });
 
   const handleFollowUser = (isFollowed: boolean) => () => {
-    // 만약, 내가 팔로우한 사람이 이미 최대인 경우(1천명) 팔로우 요청 할 수 없음
     if (userMeData && userMeData?.followingCount >= MAX_FOLLOWING) {
-      // TODO 토스트 메세지 적용이 안되서 우선 주석처리 해둠
+      // TODO 토스트 메세지 적용이 안돼서 우선 주석처리 해둠
       // toasting({ type: 'warning', txt: '최대 1000명까지 팔로우할 수 있어요.' });
       return;
     }
 
     if (isFollowed) {
-      // 이미 팔로잉 상태이므로 팔로우 취소
       deleteFollowingUser.mutate();
     } else {
-      // 팔로우 하기
       followUser.mutate();
     }
   };

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -14,14 +14,12 @@ import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { UserType } from '@/lib/types/userProfileType';
 import { useUser } from '@/store/useUser';
 import toasting from '@/lib/utils/toasting';
-import { toastMessage } from '@/lib/constants/toastMessage';
+import { MAX_FOLLOWING, toastMessage } from '@/lib/constants/toastMessage';
 
 interface FollowButtonProps {
   userId: number;
   isFollowed: boolean;
 }
-
-const MAX_FOLLOWING = 1000;
 
 export default function FollowButton({ isFollowed, userId }: FollowButtonProps) {
   const queryClient = useQueryClient();
@@ -61,14 +59,13 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
   });
 
   const handleFollowUser = (isFollowed: boolean) => () => {
-    if (userMeData && userMeData?.followingCount >= MAX_FOLLOWING) {
-      toasting({ type: 'warning', txt: toastMessage.ko.limitFollow });
-      return;
-    }
-
     if (isFollowed) {
       deleteFollowingUser.mutate();
     } else {
+      if (userMeData && userMeData?.followingCount >= MAX_FOLLOWING) {
+        toasting({ type: 'warning', txt: toastMessage.ko.limitFollow });
+        return;
+      }
       followUser.mutate();
     }
   };

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -13,7 +13,7 @@ import getUserOne from '@/app/_api/user/getUserOne';
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { UserType } from '@/lib/types/userProfileType';
 import { useUser } from '@/store/useUser';
-// import toasting from '@/lib/utils/toasting'; // 나중에 사용얘정 토스트
+import toasting from '@/lib/utils/toasting';
 
 interface FollowButtonProps {
   userId: number;
@@ -30,6 +30,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
   const { data: userMeData } = useQuery<UserType>({
     queryKey: [QUERY_KEYS.userOne, userMe.id],
     queryFn: () => getUserOne(userMe.id),
+    enabled: !!userMe.id,
   });
 
   const followUser = useMutation({
@@ -42,7 +43,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
     },
     onError: (error: AxiosError) => {
       if (error.response?.status === 401) {
-        // TODO 토스트 메세지 적용하기
+        toasting({ type: 'warning', txt: '로그인이 필요한 기능입니다.' });
         router.push('/login');
       }
     },
@@ -60,8 +61,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
 
   const handleFollowUser = (isFollowed: boolean) => () => {
     if (userMeData && userMeData?.followingCount >= MAX_FOLLOWING) {
-      // TODO 토스트 메세지 적용이 안돼서 우선 주석처리 해둠
-      // toasting({ type: 'warning', txt: '최대 1000명까지 팔로우할 수 있어요.' });
+      toasting({ type: 'warning', txt: '최대 1000명까지 팔로우할 수 있어요.' });
       return;
     }
 

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -4,24 +4,42 @@
  TODO
  - [ ] 상태(팔로우, 언팔로우)에 따른 팔로우 버튼 UI
  - [ ] 조건(비회원, 회원)에 따른 팔로우 버튼 동작(api 연동)
+ - [ ] 최대 1,000명까지 팔로우 제한 - 토스트 에러
  */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import * as styles from './FollowButton.css';
 
-interface ActionProps {
+import createFollowUser from '@/app/_api/follow/createFollowUser';
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+
+interface FollowButtonProps {
+  userId: number;
   isFollowed: boolean;
 }
 
-export default function FollowButton({ isFollowed }: ActionProps) {
-  const label = isFollowed ? '팔로우' : '팔로우 취소';
+export default function FollowButton({ isFollowed, userId }: FollowButtonProps) {
+  const queryClient = useQueryClient();
+
+  const followUser = useMutation({
+    mutationKey: [QUERY_KEYS.follow, userId],
+    mutationFn: () => createFollowUser(userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.userOne, userId],
+      });
+    },
+  });
 
   const handleFollowUser = () => {
-    // 1. follow 하는 api 요청 + update
+    followUser.mutate();
+    console.log(followUser.data);
   };
 
   return (
     <button className={styles.button} onClick={handleFollowUser}>
-      {label}
+      {isFollowed ? '팔로우 취소' : '팔로우'}
     </button>
   );
 }

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -2,7 +2,7 @@
 
 /**
  TODO
- - [ ] 상태(팔로우, 언팔로우)에 따른 팔로우 버튼 UI
+ - [x] 상태(팔로우, 언팔로우)에 따른 팔로우 버튼 UI
  - [ ] 조건(비회원, 회원)에 따른 팔로우 버튼 동작(api 연동)
  - [ ] 최대 1,000명까지 팔로우 제한 - 토스트 에러
  */
@@ -34,11 +34,10 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
 
   const handleFollowUser = () => {
     followUser.mutate();
-    console.log(followUser.data);
   };
 
   return (
-    <button className={styles.button} onClick={handleFollowUser}>
+    <button className={`${isFollowed ? styles.variant.gray : styles.variant.primary}`} onClick={handleFollowUser}>
       {isFollowed ? '팔로우 취소' : '팔로우'}
     </button>
   );

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -14,6 +14,7 @@ import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { UserType } from '@/lib/types/userProfileType';
 import { useUser } from '@/store/useUser';
 import toasting from '@/lib/utils/toasting';
+import { toastMessage } from '@/lib/constants/toastMessage';
 
 interface FollowButtonProps {
   userId: number;
@@ -43,7 +44,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
     },
     onError: (error: AxiosError) => {
       if (error.response?.status === 401) {
-        toasting({ type: 'warning', txt: '로그인이 필요해요.' });
+        toasting({ type: 'warning', txt: toastMessage.ko.requiredLogin });
         router.push('/login');
       }
     },
@@ -61,7 +62,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
 
   const handleFollowUser = (isFollowed: boolean) => () => {
     if (userMeData && userMeData?.followingCount >= MAX_FOLLOWING) {
-      toasting({ type: 'warning', txt: '최대 1,000명까지 팔로우할 수 있어요.' });
+      toasting({ type: 'warning', txt: toastMessage.ko.limitFollow });
       return;
     }
 

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -3,11 +3,14 @@
 /**
  TODO
  - [x] 상태(팔로우, 언팔로우)에 따른 팔로우 버튼 UI
- - [ ] 조건(비회원, 회원)에 따른 팔로우 버튼 동작(api 연동)
+ - [x] 조건(비회원, 회원)에 따른 팔로우 버튼 동작(api 연동)
+ - [ ] 팔로우 취소 api 연동
  - [ ] 최대 1,000명까지 팔로우 제한 - 토스트 에러
  */
 
+import { useRouter } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
 import * as styles from './FollowButton.css';
 
@@ -21,6 +24,7 @@ interface FollowButtonProps {
 
 export default function FollowButton({ isFollowed, userId }: FollowButtonProps) {
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const followUser = useMutation({
     mutationKey: [QUERY_KEYS.follow, userId],
@@ -29,6 +33,12 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.userOne, userId],
       });
+    },
+    onError: (error: AxiosError) => {
+      if (error.response?.status === 401) {
+        // TODO 토스트 메세지 적용하기
+        router.push('/login');
+      }
     },
   });
 

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -43,7 +43,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
     },
     onError: (error: AxiosError) => {
       if (error.response?.status === 401) {
-        toasting({ type: 'warning', txt: '로그인이 필요한 기능입니다.' });
+        toasting({ type: 'warning', txt: '로그인이 필요해요.' });
         router.push('/login');
       }
     },
@@ -61,7 +61,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
 
   const handleFollowUser = (isFollowed: boolean) => () => {
     if (userMeData && userMeData?.followingCount >= MAX_FOLLOWING) {
-      toasting({ type: 'warning', txt: '최대 1000명까지 팔로우할 수 있어요.' });
+      toasting({ type: 'warning', txt: '최대 1,000명까지 팔로우할 수 있어요.' });
       return;
     }
 

--- a/src/app/user/[userId]/_components/Profile.tsx
+++ b/src/app/user/[userId]/_components/Profile.tsx
@@ -16,7 +16,7 @@ import FollowButton from './FollowButton';
 import SettingIcon from '/public/icons/setting.svg';
 
 import useMoveToPage from '@/hooks/useMoveToPage';
-import { getUserOne } from '@/app/_api/user/getUserOne';
+import getUserOne from '@/app/_api/user/getUserOne';
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { UserType } from '@/lib/types/userProfileType';
 
@@ -78,11 +78,11 @@ export default function Profile({ userId }: { userId: number }) {
           <div className={styles.info}>
             <div className={styles.user}>
               <span className={styles.nickName}>{data?.nickname}</span>
-              {/* TODO 로그인 상태가 아닌 상태에서 팔로우 버튼을 누르면 로그인 페이지로 이동 */}
               {!data?.isOwner && <FollowButton userId={userId} isFollowed={!!data?.isFollowed} />}
             </div>
             <div className={styles.follow}>
               <div className={styles.text} onClick={onClickMoveToPage(`/user/${userId}/followings`)}>
+                {/* TODO 팔로우 요청/취소에 따른 버튼, 숫자 변화 최종 확인하기 */}
                 {/* TODO 숫자 3자리수 컴마 */}
                 <span className={styles.count}>{data?.followingCount}</span>
                 <span>팔로잉</span>

--- a/src/app/user/[userId]/_components/Profile.tsx
+++ b/src/app/user/[userId]/_components/Profile.tsx
@@ -19,6 +19,7 @@ import useMoveToPage from '@/hooks/useMoveToPage';
 import getUserOne from '@/app/_api/user/getUserOne';
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { UserType } from '@/lib/types/userProfileType';
+import numberFormatter from '@/lib/utils/numberFormatter';
 
 export default function Profile({ userId }: { userId: number }) {
   const [hasError, setHasError] = useState(false);
@@ -82,11 +83,15 @@ export default function Profile({ userId }: { userId: number }) {
             </div>
             <div className={styles.follow}>
               <div className={styles.text} onClick={onClickMoveToPage(`/user/${userId}/followings`)}>
-                <span className={styles.count}>{data?.followingCount.toLocaleString('ko-KR')}</span>
+                <span className={styles.count}>
+                  {data?.followingCount !== undefined && numberFormatter(data.followingCount, 'ko')}
+                </span>
                 <span>팔로잉</span>
               </div>
               <div className={styles.text} onClick={onClickMoveToPage(`/user/${userId}/followers`)}>
-                <span className={styles.count}>{data?.followerCount.toLocaleString('ko-KR')}</span>
+                <span className={styles.count}>
+                  {data?.followerCount !== undefined && numberFormatter(data?.followerCount, 'ko')}
+                </span>
                 <span>팔로워</span>
               </div>
             </div>

--- a/src/app/user/[userId]/_components/Profile.tsx
+++ b/src/app/user/[userId]/_components/Profile.tsx
@@ -78,10 +78,12 @@ export default function Profile({ userId }: { userId: number }) {
           <div className={styles.info}>
             <div className={styles.user}>
               <span className={styles.nickName}>{data?.nickname}</span>
-              {!data?.isOwner && <FollowButton isFollowed={!!data?.isFollowed} />}
+              {/* TODO 로그인 상태가 아닌 상태에서 팔로우 버튼을 누르면 로그인 페이지로 이동 */}
+              {!data?.isOwner && <FollowButton userId={userId} isFollowed={!!data?.isFollowed} />}
             </div>
             <div className={styles.follow}>
               <div className={styles.text} onClick={onClickMoveToPage(`/user/${userId}/followings`)}>
+                {/* TODO 숫자 3자리수 컴마 */}
                 <span className={styles.count}>{data?.followingCount}</span>
                 <span>팔로잉</span>
               </div>

--- a/src/app/user/[userId]/_components/Profile.tsx
+++ b/src/app/user/[userId]/_components/Profile.tsx
@@ -83,12 +83,11 @@ export default function Profile({ userId }: { userId: number }) {
             <div className={styles.follow}>
               <div className={styles.text} onClick={onClickMoveToPage(`/user/${userId}/followings`)}>
                 {/* TODO 팔로우 요청/취소에 따른 버튼, 숫자 변화 최종 확인하기 */}
-                {/* TODO 숫자 3자리수 컴마 */}
-                <span className={styles.count}>{data?.followingCount}</span>
+                <span className={styles.count}>{data?.followingCount.toLocaleString('ko-KR')}</span>
                 <span>팔로잉</span>
               </div>
               <div className={styles.text} onClick={onClickMoveToPage(`/user/${userId}/followers`)}>
-                <span className={styles.count}>{data?.followerCount}</span>
+                <span className={styles.count}>{data?.followerCount.toLocaleString('ko-KR')}</span>
                 <span>팔로워</span>
               </div>
             </div>

--- a/src/app/user/[userId]/_components/Profile.tsx
+++ b/src/app/user/[userId]/_components/Profile.tsx
@@ -90,7 +90,7 @@ export default function Profile({ userId }: { userId: number }) {
               </div>
               <div className={styles.text} onClick={onClickMoveToPage(`/user/${userId}/followers`)}>
                 <span className={styles.count}>
-                  {data?.followerCount !== undefined && numberFormatter(data?.followerCount, 'ko')}
+                  {data?.followerCount !== undefined && numberFormatter(data.followerCount, 'ko')}
                 </span>
                 <span>팔로워</span>
               </div>

--- a/src/app/user/[userId]/_components/Profile.tsx
+++ b/src/app/user/[userId]/_components/Profile.tsx
@@ -82,7 +82,6 @@ export default function Profile({ userId }: { userId: number }) {
             </div>
             <div className={styles.follow}>
               <div className={styles.text} onClick={onClickMoveToPage(`/user/${userId}/followings`)}>
-                {/* TODO 팔로우 요청/취소에 따른 버튼, 숫자 변화 최종 확인하기 */}
                 <span className={styles.count}>{data?.followingCount.toLocaleString('ko-KR')}</span>
                 <span>팔로잉</span>
               </div>

--- a/src/lib/constants/queryKeys.ts
+++ b/src/lib/constants/queryKeys.ts
@@ -10,4 +10,5 @@ export const QUERY_KEYS = {
   getRecommendedUsers: 'getRecommendedUsers',
   getTrendingLists: 'getTrendingLists',
   follow: 'follow',
+  deleteFollow: 'deleteFollow',
 };

--- a/src/lib/constants/queryKeys.ts
+++ b/src/lib/constants/queryKeys.ts
@@ -9,4 +9,5 @@ export const QUERY_KEYS = {
   getRecommendedLists: 'getRecommendedLists',
   getRecommendedUsers: 'getRecommendedUsers',
   getTrendingLists: 'getTrendingLists',
+  follow: 'follow',
 };

--- a/src/lib/constants/toastMessage.ts
+++ b/src/lib/constants/toastMessage.ts
@@ -3,10 +3,12 @@ export const creaetListToastMessage = {
   createListError: '리스트 생성에 실패했어요. 다시 시도해주세요.',
 };
 
+export const MAX_FOLLOWING = 1000;
+
 export const toastMessage = {
   ko: {
     requiredLogin: '로그인이 필요해요.',
-    limitFollow: '최대 1,000명까지 팔로우할 수 있어요',
+    limitFollow: `최대 ${MAX_FOLLOWING.toLocaleString('ko-KR')}명까지 팔로우할 수 있어요.`,
   },
   // 언어변경 시, en 추가
 };

--- a/src/lib/constants/toastMessage.ts
+++ b/src/lib/constants/toastMessage.ts
@@ -2,3 +2,11 @@ export const creaetListToastMessage = {
   uploadImageError: '이미지를 업로드 하는 중에 오류가 발생했어요. 다시 업로드해주세요.',
   createListError: '리스트 생성에 실패했어요. 다시 시도해주세요.',
 };
+
+export const toastMessage = {
+  ko: {
+    requiredLogin: '로그인이 필요해요.',
+    limitFollow: '최대 1,000명까지 팔로우할 수 있어요',
+  },
+  // 언어변경 시, en 추가
+};

--- a/src/lib/types/listType.ts
+++ b/src/lib/types/listType.ts
@@ -78,8 +78,8 @@ export interface ItemType {
   id: number;
   rank: number;
   title: string;
-  comment?: string; 
-  link?: string; 
+  comment?: string;
+  link?: string;
   imageUrl?: string;
 }
 

--- a/src/lib/types/listType.ts
+++ b/src/lib/types/listType.ts
@@ -81,6 +81,7 @@ export interface ListDetailType {
   collectCount: number;
   viewCount: number;
 }
+
 // 리스트 전체 조회 타입
 export interface AllListType {
   cursorId: number;
@@ -98,9 +99,9 @@ export interface ListType {
 
 export interface ItemType {
   id: number;
-  ranking: number;
+  rank: number;
   title: string;
-  comment?: string;
-  link?: string;
+  comment?: string; // 리스트 상세조회 타입에서 사용할때는 optional 여부 확인하기
+  link?: string; // 리스트 상세조회 타입에서 사용할때는 optional 여부 확인하기
   imageUrl?: string;
 }

--- a/src/lib/utils/numberFormatter.ts
+++ b/src/lib/utils/numberFormatter.ts
@@ -1,3 +1,15 @@
+/**
+ * 숫자 형태를 단위에 맞게 변환해주는 포매팅 함수입니다.
+ - 만 미만: 축약 없이 컴마(,) 처리 ex. 1~9,999 (ko, en)
+ - 만 이상: 만 단위 ex. 1만, 35.5만, 510만... (ko)
+ - 만 이상: K 단위(소숫점 1자리) ex. 10K, 355.3K (en)
+ - 백만 이상: M 단위(소숫점 1자리) ex. 5.1M (en)
+
+ * @param {number} num 축약할 숫자입니다.
+ * @param {'ko' | 'en'} lang 적용할 숫자 국가 단위입니다.
+ * @returns {number} 단위에 맞게 변환된 숫자입니다.
+ */
+
 const numberFormatter = (num: number, lang: 'ko' | 'en') => {
   const unit = 10000;
 

--- a/src/lib/utils/numberFormatter.ts
+++ b/src/lib/utils/numberFormatter.ts
@@ -1,16 +1,22 @@
 const numberFormatter = (num: number, lang: 'ko' | 'en') => {
   const unit = 10000;
 
-  console.log(num); // 삭제 예정
-
   if (num / unit < 1) {
     return num.toLocaleString('ko-KR');
   }
 
-  const formattedNum = Math.trunc((num / unit) * 10) / 10;
-  console.log(formattedNum); // 삭제 예정
-
-  return formattedNum + '만';
+  if (lang === 'ko') {
+    const formattedNumKo = Math.trunc((num / unit) * 10) / 10;
+    return formattedNumKo + '만';
+  } else {
+    const formattedNumEn = Math.trunc((num / unit) * 10);
+    if (formattedNumEn < 1000) {
+      return formattedNumEn + 'K';
+    } else {
+      const formattedMillion = Math.trunc((formattedNumEn / 1000) * 10) / 10;
+      return formattedMillion + 'M';
+    }
+  }
 };
 
 export default numberFormatter;

--- a/src/lib/utils/numberFormatter.ts
+++ b/src/lib/utils/numberFormatter.ts
@@ -1,0 +1,16 @@
+const numberFormatter = (num: number, lang: 'ko' | 'en') => {
+  const unit = 10000;
+
+  console.log(num); // 삭제 예정
+
+  if (num / unit < 1) {
+    return num.toLocaleString('ko-KR');
+  }
+
+  const formattedNum = Math.trunc((num / unit) * 10) / 10;
+  console.log(formattedNum); // 삭제 예정
+
+  return formattedNum + '만';
+};
+
+export default numberFormatter;


### PR DESCRIPTION
## 개요

- 마이리스트, 콜라보리스트 페이지에서 팔로우/팔로잉 기능을 구현했습니다.

<br>

## 작업 사항

- 사용자 프로필에서 [팔로우] 버튼을 클릭하면 해당 사용자를 팔로잉하게 됩니다.
- 이미 팔로잉한 사용자라면 [팔로우 취소] 버튼이 보이고, 버튼을 클릭하면 해당 사용자 팔로우를 취소하게 됩니다.
- 로그인한 상태가 아니라면 [팔로우] 버튼만 보이고, 버튼을 클릭하면 로그인 페이지로 이동하게 됩니다. (+. 토스트 메세지)
- 위의 3가지 상태에 따른 프로필 상태 UI 반영 
- 팔로잉 여부에 따른 본인 프로필, 팔로우 한 사용자 프로필 count update
- 팔로우 요청 제한 설정(최대 1천명) (*팔로워는 제한 x) (+. 토스트 메세지)
- 본인 리스트 접근 시에는 [팔로우] 버튼 대신 설정(마이페이지 이동) 아이콘이 보임
- 리스트 목록 중 아이템 리스폰스 타입 수정 (ranking -> rank)

<br>

## 참고 사항 (optional)

- 리스트 조회 페이지에서 사용자 프로필 조회시, 팔로우된 상태 여부를 리스폰스로 받아옵니다.
  ㄴ 현재 팔로우 요청이 정상적으로 들어간 이후에도 사용자에게 반영되지 않은 상태라서, 백엔드의 수정이 필요한 부분입니다. (완료)
  ㄴ 내일까지 수정 요청 드릴 예정이며, 이후 스크린샷 첨부하도록 하겠습니다. 

<br>

## 스크린샷

- 내일 api 수정 후 반영하여 스크린샷 첨부하도록 하겠습니다. 📸 (첨부 완료)
![Feb-14-2024 11-23-09](https://github.com/8-Sprinters/ListyWave-front/assets/124856726/28ad7e6e-de43-4ff5-ae4e-e60cadd947e3)

<br>

## 리뷰어에게

- **위의 참고사항 내용 확인 및 반영 후에 최종 merge 예정입니다.** (완료)
- 코드 자체는 큰 수정이 없을 것 같아서 PR 먼저 올립니다. 리뷰는 시간나실 때 천천히 부탁드립니다. 감사합니다. ❤️‍🔥

<br>
