### PR TITLE
HOTFIX: axiosInstance config에 Bearer 옵션 설정

### DIFF
--- a/src/lib/axios/axiosInstance.ts
+++ b/src/lib/axios/axiosInstance.ts
@@ -11,7 +11,7 @@ axiosInstance.interceptors.request.use(
     const accessToken = useUser.getState().user.accessToken;
 
     if (accessToken) {
-      config.headers.Authorization = `${accessToken}`; // Bearer option 추가 예정
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
 
     return config;


### PR DESCRIPTION
## 개요

- 백엔드 Authorization 헤더 prefix 수정에 따른 axiosInstance config에 Bearer 옵션 추가

<br>

## 작업 사항

-  axiosInstance config에 Bearer 옵션 추가

<br>

## 스크린샷

-  api를 잘 불러오고 있습니다!!!
![스크린샷 2024-02-14 오후 3 58 13](https://github.com/8-Sprinters/ListyWave-front/assets/124856726/7ef2bce4-90f1-4763-aed8-b8e0019112fa)


<br>

## 리뷰어에게

- 해당 pr merge전까지는 로그인을 해도 Unauthorize 에러가 발생하고 있습니다. 참고 부탁드립니다.

<br>
