### PR TITLE
Feat: 팔로잉/팔로워 조회 페이지 API 연결 및 리스트 생성 페이지 유저 검색 API 연결 완료

### DIFF
--- a/src/app/_api/follow/deleteFollower.ts
+++ b/src/app/_api/follow/deleteFollower.ts
@@ -1,0 +1,7 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+
+const deleteFollower = async (userId: number) => {
+  return await axiosInstance.delete(`/followers/${userId}`);
+};
+
+export default deleteFollower;

--- a/src/app/_api/follow/getFollowerList.ts
+++ b/src/app/_api/follow/getFollowerList.ts
@@ -1,0 +1,11 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { FollowerListType } from '@/lib/types/followType';
+
+const getFollowerList = async (userId: number) => {
+  const response = await axiosInstance.get<FollowerListType>(`/users/${userId}/followers`);
+  //   const response = await axiosInstance.get<FollowerListType>(`/users/${userId}/followers?size={}&cursorId={}`);
+
+  return response.data;
+};
+
+export default getFollowerList;

--- a/src/app/_api/follow/getFollowingList.ts
+++ b/src/app/_api/follow/getFollowingList.ts
@@ -1,7 +1,7 @@
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { FollowingListType } from '@/lib/types/followType';
 
-const getFollowingList = async (userId: number) => {
+const getFollowingList = async (userId: number | null) => {
   const response = await axiosInstance.get<FollowingListType>(`users/${userId}/followings`);
 
   return response.data;

--- a/src/app/_api/follow/getFollowingList.ts
+++ b/src/app/_api/follow/getFollowingList.ts
@@ -1,0 +1,10 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { FollowingListType } from '@/lib/types/followType';
+
+const getFollowingList = async (userId: number) => {
+  const response = await axiosInstance.get<FollowingListType>(`users/${userId}/followings`);
+
+  return response.data;
+};
+
+export default getFollowingList;

--- a/src/app/_api/user/getUsersByNicknameSearch.ts
+++ b/src/app/_api/user/getUsersByNicknameSearch.ts
@@ -1,0 +1,11 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { UserSearchType } from '@/lib/types/user';
+
+const getUsersByNicknameSearch = async (search: string) => {
+  const response = await axiosInstance.get<UserSearchType>(`/collaborators?search=${search}`);
+  // const response = await axiosInstance.get<UserSearchType>(`/collaborators?search=${search}&size={}&page={}`);
+
+  return response.data;
+};
+
+export default getUsersByNicknameSearch;

--- a/src/app/list/create/_components/list/MemberSelector.tsx
+++ b/src/app/list/create/_components/list/MemberSelector.tsx
@@ -1,18 +1,24 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
 
 import UserProfileImage from '@/components/UserProfileImage/UserProfileImage';
 import SearchIcon from '/public/icons/search.svg';
 import EraseButton from '/public/icons/x_circle_fill.svg';
 
-import * as styles from './MemberSelector.css';
-
+import getListDetail from '@/app/_api/list/getListDetail';
+import getUsersByNicknameSearch from '@/app/_api/user/getUsersByNicknameSearch';
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+import { UserSearchType } from '@/lib/types/user';
 import { UserProfileType } from '@/lib/types/userProfileType';
+import { ListDetailType } from '@/lib/types/listType';
+
+import * as styles from './MemberSelector.css';
 
 interface MemberSelectorProps {
   placeholder: string;
-  members: UserProfileType[];
-  fetchData: () => Promise<void>;
+  followingList: UserProfileType[];
   onClickAdd: (userId: number) => void;
   onClickDelete: (userId: number) => void;
   rules?: {
@@ -24,7 +30,6 @@ interface MemberSelectorProps {
       errorMessage: string;
     };
   };
-  defaultValue?: UserProfileType[];
 }
 
 /**
@@ -32,27 +37,30 @@ interface MemberSelectorProps {
  * 사용자의 프로필 목록을 보여주고, 검색을 통해 사용자를 선택하는 기능 제공
  *
  * @param placeholder - 검색 입력란에 보여질 placeholder
- * @param members - 드롭다운 보여질 사용자 프로필 목록
- * @param fetchData - 검색어가 입력됨에따라 보여질 멤버 목록을 업데이트할 함수
+ * @param followingList - 처음 드롭다운에 보여질 팔로우한 사용자 목록
  * @param onClickAdd - 선택한 멤버를 추가하는 함수
  * @param onClickDelete - 사용자를 선택 취소하는 함수
  */
-function MemberSelector({
-  placeholder,
-  members = [],
-  fetchData,
-  onClickAdd,
-  onClickDelete,
-  rules,
-  defaultValue,
-}: MemberSelectorProps) {
+function MemberSelector({ placeholder, followingList, onClickAdd, onClickDelete, rules }: MemberSelectorProps) {
   const [input, setInput] = useState('');
-  const [selectedList, setSelectedList] = useState<UserProfileType[]>(defaultValue || []);
+  const [selectedList, setSelectedList] = useState<UserProfileType[]>([]);
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+
+  const { data: searchResult } = useQuery<UserSearchType>({
+    queryKey: [QUERY_KEYS.getUsersByNicknameSearch, input],
+    queryFn: () => getUsersByNicknameSearch(input),
+  });
+
+  const param = useParams<{ userId: string; listId: string }>();
+
+  const { data: listDataBeforeEdit } = useQuery<ListDetailType>({
+    queryKey: [QUERY_KEYS.getListDetail, param?.listId],
+    queryFn: () => getListDetail(Number(param?.listId)),
+  });
 
   useEffect(() => {
     const closeDropdown = (event: MouseEvent) => {
@@ -69,18 +77,14 @@ function MemberSelector({
     };
     document.addEventListener('click', closeDropdown);
 
-    fetchData();
-
     return () => {
       document.removeEventListener('click', closeDropdown);
     };
   }, []);
 
   useEffect(() => {
-    if (defaultValue) {
-      setSelectedList(defaultValue);
-    }
-  }, [defaultValue]);
+    if (listDataBeforeEdit) setSelectedList(listDataBeforeEdit.collaborators);
+  }, [listDataBeforeEdit]);
 
   return (
     <div className={styles.container}>
@@ -102,31 +106,70 @@ function MemberSelector({
       {/* 멤버 검색 드롭다운 */}
       {isDropDownOpen && (
         <div className={styles.dropdown} ref={dropdownRef} style={{ height: isDropDownOpen ? '152px' : '0' }}>
-          {members
-            .filter((user) => user.nickname.toLocaleLowerCase().includes(input.toLocaleLowerCase()))
-            .map((user) => (
-              <div
-                key={user.id}
-                className={styles.profileContainer}
-                onClick={() => {
-                  if (rules?.maxNum && selectedList.length >= rules.maxNum.value) {
-                    return;
-                  }
-                  if (!selectedList.find((selectedUser: UserProfileType) => selectedUser.id === user.id)) {
-                    setSelectedList([...selectedList, user]);
-                    onClickAdd(user.id);
-                  }
-                }}
-              >
-                <UserProfileImage src={user.profileImageUrl} size={30} />
-                {user.nickname}
-                {selectedList.find((collaboUser: UserProfileType) => collaboUser.id === user.id) && (
-                  <span className={styles.checkedIcon}>✓</span>
-                )}
-              </div>
-            ))}
-          {members.filter((user) => user.nickname.toLocaleLowerCase().includes(input.toLocaleLowerCase())).length ===
-            0 && <div className={styles.noResultMessage}>검색결과가 없어요.</div>}
+          {input !== '' ? (
+            searchResult?.collaborators.length === 0 ? (
+              <>
+                {searchResult?.collaborators.filter((user) =>
+                  user.nickname.toLocaleLowerCase().includes(input.toLocaleLowerCase())
+                ).length === 0 && <div className={styles.noResultMessage}>검색결과가 없어요.</div>}
+              </>
+            ) : (
+              <>
+                {searchResult?.collaborators.map((user) => (
+                  <div
+                    key={user.id}
+                    className={styles.profileContainer}
+                    onClick={() => {
+                      if (rules?.maxNum && selectedList.length >= rules.maxNum.value) {
+                        return;
+                      }
+                      if (!selectedList.find((selectedUser: UserProfileType) => selectedUser.id === user.id)) {
+                        console.log(user);
+                        setSelectedList([...selectedList, user]);
+                        onClickAdd(user.id);
+                      }
+                    }}
+                  >
+                    <UserProfileImage src={user.profileImageUrl} size={30} />
+                    {user.nickname}
+                    {selectedList.find((collaboUser: UserProfileType) => collaboUser.id === user.id) && (
+                      <span className={styles.checkedIcon}>✓</span>
+                    )}
+                  </div>
+                ))}
+              </>
+            )
+          ) : followingList.length === 0 ? (
+            <>
+              {searchResult?.collaborators.filter((user) =>
+                user.nickname.toLocaleLowerCase().includes(input.toLocaleLowerCase())
+              ).length === 0 && <div className={styles.noResultMessage}>검색결과가 없어요.</div>}
+            </>
+          ) : (
+            <>
+              {followingList.map((user) => (
+                <div
+                  key={user.id}
+                  className={styles.profileContainer}
+                  onClick={() => {
+                    if (rules?.maxNum && selectedList.length >= rules.maxNum.value) {
+                      return;
+                    }
+                    if (!selectedList.find((selectedUser: UserProfileType) => selectedUser.id === user.id)) {
+                      setSelectedList([...selectedList, user]);
+                      onClickAdd(user.id);
+                    }
+                  }}
+                >
+                  <UserProfileImage src={user.profileImageUrl} size={30} />
+                  {user.nickname}
+                  {selectedList.find((collaboUser: UserProfileType) => collaboUser.id === user.id) && (
+                    <span className={styles.checkedIcon}>✓</span>
+                  )}
+                </div>
+              ))}
+            </>
+          )}
         </div>
       )}
       {rules?.maxNum && selectedList.length >= rules.maxNum.value && (

--- a/src/app/user/[userId]/(follow)/_components/UserList.css.ts
+++ b/src/app/user/[userId]/(follow)/_components/UserList.css.ts
@@ -37,5 +37,9 @@ export const button = style({
 });
 
 export const emptyMessage = style({
+  marginTop: '18px',
+
   fontSize: '1.6rem',
+
+  textAlign: 'center',
 });

--- a/src/app/user/[userId]/(follow)/_components/UserList.tsx
+++ b/src/app/user/[userId]/(follow)/_components/UserList.tsx
@@ -1,19 +1,62 @@
 'use client';
 
+import { ReactNode } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import UserProfileImage from '@/components/UserProfileImage/UserProfileImage';
+import deleteFollower from '@/app/_api/follow/deleteFollower';
+import { useUser } from '@/store/useUser';
 import { UserProfileType } from '@/lib/types/userProfileType';
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+
 import * as styles from './UserList.css';
-import { useRouter } from 'next/navigation';
+
+const BUTTON_MESSAGE = {
+  ko: {
+    delete: '삭제',
+  },
+};
+
+const EMPTY_MESSAGE = {
+  ko: {
+    follower: '아직은 팔로워가 없어요',
+    following: '아직 팔로우한 사람이 없어요',
+  },
+};
+
+function DeleteFollowerButton({ userId }: { userId: number }) {
+  const queryClient = useQueryClient();
+
+  const deleteUser = useMutation({
+    mutationKey: [QUERY_KEYS.deleteFollower, userId],
+    mutationFn: () => deleteFollower(userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.userOne, userId],
+      });
+    },
+  });
+
+  return (
+    <button
+      className={styles.button}
+      onClick={() => {
+        deleteUser.mutate();
+      }}
+    >
+      {BUTTON_MESSAGE.ko.delete}
+    </button>
+  );
+}
 
 interface UserProps {
   user: UserProfileType;
-  button?: {
-    name: string;
-    onClick: () => void;
-  };
+  button?: ReactNode;
+  isOwner?: boolean;
 }
 
-function User({ user, button }: UserProps) {
+function User({ user, button, isOwner }: UserProps) {
   const router = useRouter();
 
   return (
@@ -27,9 +70,7 @@ function User({ user, button }: UserProps) {
         <UserProfileImage src={user.profileImageUrl} size={50} />
         {user.nickname}
       </div>
-      <button className={styles.button} onClick={button?.onClick}>
-        {button?.name}
-      </button>
+      {isOwner ? button : null}
     </div>
   );
 }
@@ -39,43 +80,23 @@ interface UserListProps {
   list: UserProfileType[];
 }
 
-const data = {
-  follower: {
-    emptyMessage: '아직은 팔로워가 없어요',
-    button: {
-      name: '삭제',
-      onClick: () => {
-        console.log('팔로워 삭제'); //삭제 예정
-      },
-    },
-  },
-  following: {
-    emptyMessage: '아직 팔로우한 사람이 없어요',
-    button: {
-      name: '취소',
-      onClick: () => {
-        console.log('팔로잉 취소'); //삭제 예정
-      },
-    },
-  },
-};
-
 function UserList({ type, list }: UserListProps) {
+  const { user: me } = useUser();
+  const params = useParams<{ userId: string }>();
+  const isOwner = Number(params?.userId) === me.id;
+
   return (
     <div className={styles.container}>
       {list.length === 0 ? (
-        <div className={styles.emptyMessage}>{data[type].emptyMessage}</div>
+        <div className={styles.emptyMessage}>{EMPTY_MESSAGE.ko[type]}</div>
       ) : (
-        list.map((user) => (
-          <User
-            key={user.id}
-            user={user}
-            button={{
-              name: data[type].button.name,
-              onClick: data[type].button.onClick,
-            }}
-          />
-        ))
+        <>
+          {type === 'following' && list?.map((user: UserProfileType) => <User key={user.id} user={user} />)}
+          {type === 'follower' &&
+            list?.map((user: UserProfileType) => (
+              <User key={user.id} user={user} button={<DeleteFollowerButton userId={user.id} />} isOwner={isOwner} />
+            ))}
+        </>
       )}
     </div>
   );

--- a/src/app/user/[userId]/(follow)/followers/page.tsx
+++ b/src/app/user/[userId]/(follow)/followers/page.tsx
@@ -1,12 +1,28 @@
+'use client';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+
 import Header from '../_components/Header';
 import UserList from '../_components/UserList';
-import { mockFollowers } from '../_components/mockData';
 
-export default function FollowersPage() {
+import getFollowerList from '@/app/_api/follow/getFollowerList';
+import { FollowerListType } from '@/lib/types/followType';
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+
+function FollowersPage() {
+  const param = useParams<{ userId: string }>();
+
+  const { data: followerList } = useQuery<FollowerListType>({
+    queryKey: [QUERY_KEYS.getFollowerList],
+    queryFn: () => getFollowerList(Number(param?.userId)),
+  });
+
   return (
     <div>
       <Header title="팔로워" />
-      <UserList type="follower" list={mockFollowers} />
+      <UserList type="follower" list={followerList?.followers || []} />
     </div>
   );
 }
+
+export default FollowersPage;

--- a/src/app/user/[userId]/(follow)/followings/page.tsx
+++ b/src/app/user/[userId]/(follow)/followings/page.tsx
@@ -1,12 +1,28 @@
+'use client';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
+
 import Header from '../_components/Header';
 import UserList from '../_components/UserList';
-import { mockFollowers } from '../_components/mockData';
 
-export default function FollowingPage() {
+import getFollowingList from '@/app/_api/follow/getFollowingList';
+import { FollowingListType } from '@/lib/types/followType';
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+
+function FollowingPage() {
+  const param = useParams<{ userId: string }>();
+
+  const { data: followingList } = useQuery<FollowingListType>({
+    queryKey: [QUERY_KEYS.getFollowingList],
+    queryFn: () => getFollowingList(Number(param?.userId)),
+  });
+
   return (
     <div>
       <Header title="팔로잉" />
-      <UserList type="following" list={mockFollowers} />
+      <UserList type="following" list={followingList?.followings || []} />
     </div>
   );
 }
+
+export default FollowingPage;

--- a/src/app/user/[userId]/list/[listId]/edit/page.tsx
+++ b/src/app/user/[userId]/list/[listId]/edit/page.tsx
@@ -19,7 +19,7 @@ export default function EditPage() {
   const param = useParams<{ userId: string; listId: string }>();
 
   const { data } = useQuery<ListDetailType>({
-    queryKey: [QUERY_KEYS.getListDetail],
+    queryKey: [QUERY_KEYS.getListDetail, param?.listId],
     queryFn: () => getListDetail(Number(param?.listId)),
   });
 

--- a/src/lib/constants/queryKeys.ts
+++ b/src/lib/constants/queryKeys.ts
@@ -11,4 +11,8 @@ export const QUERY_KEYS = {
   getTrendingLists: 'getTrendingLists',
   follow: 'follow',
   deleteFollow: 'deleteFollow',
+  deleteFollower: 'deleteFollower',
+  getFollowingList: 'getFollowingList',
+  getFollowerList: 'getFollowerList',
+  getUsersByNicknameSearch: 'getUsersByNicknameSearch',
 };

--- a/src/lib/types/followType.ts
+++ b/src/lib/types/followType.ts
@@ -1,0 +1,12 @@
+import { UserProfileType } from './userProfileType';
+
+export interface FollowingListType {
+  followings: UserProfileType[];
+}
+
+export interface FollowerListType {
+  followers: UserProfileType[];
+  totalCount: number;
+  hasNext: boolean;
+  cursorId: number;
+}

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -1,3 +1,5 @@
+import { UserProfileType } from './userProfileType';
+
 // 로그인한 사용자 리스폰스 타입
 export interface UserOnLoginType {
   id: number;
@@ -9,4 +11,10 @@ export interface UserOnLoginType {
   followingCount: number;
   isFirst: boolean;
   accessToken: string;
+}
+
+export interface UserSearchType {
+  collaborators: UserProfileType[];
+  totalCount: number;
+  hasNext: boolean;
 }


### PR DESCRIPTION
## 개요

- 리스트 생성 및 수정페이지에서 팔로잉 유저 조회 API  및 유저 검색 API 연결
- 팔로잉 조회, 팔로워 조회 페이지 API 연결 및 구현

<br>

## 작업 사항

[ 팔로잉 팔로워 조회 페이지 ]
- 팔로잉 팔로워 페이지 API 연결
- 팔로잉 페이지 취소 버튼 없앰
- 본인의 팔로워 조회 페이지일때만 팔로워 삭제버튼이 보이도록 함.

[ 리스트 생성 수정 페이지 ]
- 콜라보레이터 수정에서 유저 검색 API 느림 이슈 해결
- 콜라보레이터 추가 박스 클릭시 팔로잉 리스트 조회, 검색
- 생성, 수정페이지 둘 다에서 선택한 유저가 아래에 잘 추가되고 삭제도 잘 동작합니다.

<br>

## 참고 사항

- 디바운스와 무한스크롤은 백로그로.. 아직 팔로워가 10명 미만으로 많지 않아서 히스토리 먼저 하고 이 브랜치 다시 돌아오겠습니다.
- 팔로워 삭제 기능은 내일 중으로 API 주신다고 하네요!! API 받고 삭제하시겠습니까 모달과 함께 연결하겠습니다

<br>

## 관련 이슈
- 콜라보레이터 수정에서 유저 검색 API 느림 이슈 해결
- 아래처럼 id를 포함해서 쿼리키를 지정해줬어야했는데, 리액트 쿼리에서 계층적 쿼리키 지정을 해주지 않아서 생긴 문제였습니다.
<img width="419" alt="image" src="https://github.com/8-Sprinters/ListyWave-front/assets/70089733/222554d7-fa1a-4358-841e-5e9565b4b62f">
- 마운트 된 후 useUser가 정보를 가져오기 전에 유저 0번으로 리액트 쿼리가 실행되어 캐싱된 값이 계속 유지가 되었고, 이로인해 이 캐싱이 gc에 의해 클리어 되기 전까지 이 값이 유지가 되어서 실제 id에 대한 쿼리실행결과를 가져오는데 오래 걸린거였답니다..! 

<br>

## 스크린샷
1. 콜라보레이터 추가 박스 처음 클릭했을때
<img width="375" alt="image" src="https://github.com/8-Sprinters/ListyWave-front/assets/70089733/94126de4-fd1b-445d-a765-6d2277754444">

2. 콜라보레이터 추가 박스에 검색했을때
<img width="369" alt="image" src="https://github.com/8-Sprinters/ListyWave-front/assets/70089733/b508f52e-4d22-4e60-92f3-f2f737e688fc">

3. 팔로잉 조회 페이지
<img width="387" alt="image" src="https://github.com/8-Sprinters/ListyWave-front/assets/70089733/9b8979b4-c95f-463f-9a84-79df44f54693">

4. 팔로워 조회 페이지
<img width="385" alt="image" src="https://github.com/8-Sprinters/ListyWave-front/assets/70089733/3d01137d-8b2a-4bf7-b9d5-0c1b1d765d73">

<br>

## 리뷰어에게

- 이번 PR 너무 오래 묵혀두다가 올리네요 ㅎㅎ
- 리뷰 간단히 주셔도 괜찮을것같습니다!!
- 하지만 문제있어보이는 + 개선이 필요해보이는 부분이 눈에 띄셨다면 많은 조언부탁드립니다!! 

<br>
