### PR TITLE
Feat: 로그인 refreshToken 도입 및 인가 처리

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "open-graph": "^0.2.6",
     "react": "^18",
     "react-beautiful-dnd": "^13.1.1",
+    "react-cookie": "^7.0.2",
     "react-dom": "^18",
     "react-hook-form": "^7.50.0",
     "react-scripts": "^5.0.1",

--- a/src/app/account/_components/LogoutModal.tsx
+++ b/src/app/account/_components/LogoutModal.tsx
@@ -6,6 +6,7 @@ import { AxiosError } from 'axios';
 import axiosInstance from '@/lib/axios/axiosInstance';
 import toasting from '@/lib/utils/toasting';
 import toastMessage from '@/lib/constants/toastMessage';
+import { removeCookie } from '@/lib/utils/cookie';
 
 import { useUser } from '@/store/useUser';
 
@@ -32,6 +33,9 @@ export default function LogoutModal({ handleSetOff }: LogOutModalProps) {
 
       if (result.status === 204) {
         logoutUser();
+        removeCookie('accessToken'); // TODO removeCookieAll
+        removeCookie('refreshToken');
+
         toasting({ type: 'success', txt: toastMessage.ko.loggedOut });
         router.push('/');
       }

--- a/src/app/auth/redirect/kakao/page.tsx
+++ b/src/app/auth/redirect/kakao/page.tsx
@@ -29,9 +29,10 @@ export default function KakaoRedirectPage() {
           signal: controller.signal,
         });
 
-        const { id, accessToken } = res.data;
-        updateUser({ id, accessToken }); // TODO id만 저장하기
-        setCookie('accessToken', accessToken);
+        const { id, accessToken, refreshToken } = res.data;
+        updateUser({ id, accessToken: '' }); // TODO id만 저장하기
+        setCookie('accessToken', accessToken, 'AT');
+        setCookie('refreshToken', refreshToken, 'RT');
 
         router.push('/');
       } catch (error) {

--- a/src/app/auth/redirect/kakao/page.tsx
+++ b/src/app/auth/redirect/kakao/page.tsx
@@ -37,7 +37,7 @@ export default function KakaoRedirectPage() {
         router.push('/');
       } catch (error) {
         if (error instanceof AxiosError) {
-          if (error.response?.status === 500) {
+          if (error.response?.status === 400) {
             // 탈퇴한 사용자(status 400)일 경우, 리다이렉트
             router.push('/withdrawn-account');
           } else if (!controller.signal.aborted) {

--- a/src/app/auth/redirect/kakao/page.tsx
+++ b/src/app/auth/redirect/kakao/page.tsx
@@ -7,6 +7,7 @@ import { AxiosError } from 'axios';
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { useUser } from '@/store/useUser';
 import { UserOnLoginType } from '@/lib/types/user';
+import { setCookie } from '@/lib/utils/cookie';
 
 export default function KakaoRedirectPage() {
   const router = useRouter();
@@ -29,7 +30,8 @@ export default function KakaoRedirectPage() {
         });
 
         const { id, accessToken } = res.data;
-        updateUser({ id, accessToken });
+        updateUser({ id, accessToken }); // TODO id만 저장하기
+        setCookie('accessToken', accessToken);
 
         router.push('/');
       } catch (error) {

--- a/src/app/auth/redirect/kakao/page.tsx
+++ b/src/app/auth/redirect/kakao/page.tsx
@@ -37,7 +37,10 @@ export default function KakaoRedirectPage() {
         router.push('/');
       } catch (error) {
         if (error instanceof AxiosError) {
-          if (!controller.signal.aborted) {
+          if (error.response?.status === 500) {
+            // 탈퇴한 사용자(status 400)일 경우, 리다이렉트
+            router.push('/withdrawn-account');
+          } else if (!controller.signal.aborted) {
             console.error(error.message);
           } else {
             console.log('Request canceled:', error.message);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,9 +4,11 @@ import { ReactNode } from 'react';
 import { ToastContainer } from 'react-toastify';
 import Script from 'next/script';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import BottomNav from '@/components/BottomNav/BottomNav';
-import '@/styles/GlobalStyles.css';
+import { CookiesProvider } from 'react-cookie';
 
+import BottomNav from '@/components/BottomNav/BottomNav';
+
+import '@/styles/GlobalStyles.css';
 import * as styles from './layout.css';
 
 const queryClient = new QueryClient();
@@ -36,12 +38,14 @@ export default function TempLayout({ children }: { children: ReactNode }) {
       </head>
       <body className={styles.body}>
         <QueryClientProvider client={queryClient}>
-          <div id="modal-root" />
-          <div>
-            {children}
-            <BottomNav />
-          </div>
-          <ToastContainer />
+          <CookiesProvider>
+            <div id="modal-root" />
+            <div>
+              {children}
+              <BottomNav />
+            </div>
+            <ToastContainer />
+          </CookiesProvider>
         </QueryClientProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,8 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
 import ListRecommendation from '@/components/exploreComponents/ListsRecommendation';
 import TrendingList from '@/components/exploreComponents/TrendingLists';
 import UsersRecommendation from '@/components/exploreComponents/UsersRecommendation';
@@ -5,7 +10,14 @@ import Header from '@/components/exploreComponents/Header';
 import FloatingContainer from '@/components/floatingButton/FloatingContainer';
 import PlusOptionFloatingButton from '@/components/floatingButton/PlusOptionFloatingButton';
 import ArrowUpFloatingButton from '@/components/floatingButton/ArrowUpFloatingButton';
+import Modal from '@/components/Modal/Modal';
+import LoginModal from '@/components/login/LoginModal';
+
 import * as styles from './page.css';
+
+import useBooleanOutput from '@/hooks/useBooleanOutput';
+import toasting from '@/lib/utils/toasting';
+import toastMessage from '@/lib/constants/toastMessage';
 
 interface ExplorePageProps {
   params: {
@@ -14,6 +26,21 @@ interface ExplorePageProps {
 }
 
 function LandingPage({ params }: ExplorePageProps) {
+  // TODO 소현 - 나중에 getStaticPaths, getStaticProps로 쿼리 가져오기 (리팩토링)
+  const searchParams = useSearchParams();
+  const isLoginRequired = searchParams ? searchParams.get('loginRequired') : '';
+  const { isOn, handleSetOn, handleSetOff } = useBooleanOutput();
+
+  console.log(isLoginRequired);
+
+  // TODO 소현 - hoc or hof로 분리하기
+  useEffect(() => {
+    if (!!isLoginRequired) {
+      toasting({ type: 'error', txt: toastMessage.ko.requiredLogin });
+      handleSetOn();
+    }
+  }, [isLoginRequired, handleSetOn]);
+
   return (
     <>
       <div className={styles.wrapper}>
@@ -27,6 +54,11 @@ function LandingPage({ params }: ExplorePageProps) {
           <ArrowUpFloatingButton />
         </FloatingContainer>
       </div>
+      {isOn && (
+        <Modal handleModalClose={handleSetOff} size="large">
+          <LoginModal />
+        </Modal>
+      )}
     </>
   );
 }

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -43,7 +43,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
     onError: (error: AxiosError) => {
       if (error.response?.status === 401) {
         toasting({ type: 'warning', txt: toastMessage.ko.requiredLogin });
-        router.push('/login');
+        router.push('/login'); // interceptors에서 핸들링 하므로 불필요??
       }
     },
   });

--- a/src/components/BottomNav/BottomNav.tsx
+++ b/src/components/BottomNav/BottomNav.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { usePathname } from 'next/navigation';
 
 import ExploreIcon from '/public/icons/explore.svg';
@@ -9,6 +10,8 @@ import useMoveToPage from '@/hooks/useMoveToPage';
 import { useUser } from '@/store/useUser';
 import { vars } from '@/styles/theme.css';
 import * as styles from './BottomNav.css';
+import toasting from '@/lib/utils/toasting';
+import toastMessage from '@/lib/constants/toastMessage';
 
 export default function BottomNav() {
   const { user } = useUser();
@@ -21,6 +24,14 @@ export default function BottomNav() {
   const isHidden = hiddenPaths.some((path) => pathname.includes(path));
 
   if (isHidden) return;
+
+  const handleOnclickMyfeed = () => {
+    if (!userId) {
+      toasting({ type: 'error', txt: toastMessage.ko.requiredLogin });
+      return;
+    }
+    onClickMoveToPage(`/user/${userId}/mylist`);
+  };
 
   //파란색 선택 표시를 위한 분기처리
   const selectedItem = (() => {
@@ -41,7 +52,7 @@ export default function BottomNav() {
         <li className={styles.buttonDiv} onClick={onClickMoveToPage('/')}>
           <ExploreIcon fill={selectedItem === 'explore' ? vars.color.blue : vars.color.gray7} />
         </li>
-        <li className={styles.buttonDiv} onClick={onClickMoveToPage(`/user/${userId}/mylist`)}>
+        <li className={styles.buttonDiv} onClick={handleOnclickMyfeed}>
           <MyFeedIcon fill={selectedItem === 'my-feed' ? vars.color.blue : vars.color.gray7} />
         </li>
         <li className={styles.buttonDiv} onClick={onClickMoveToPage('/collection')}>

--- a/src/lib/axios/axiosInstance.ts
+++ b/src/lib/axios/axiosInstance.ts
@@ -39,8 +39,8 @@ axiosInstance.interceptors.response.use(
     const originalRequest = error.config;
     const refreshToken = getCookie('refreshToken');
 
-    if (error.response?.status === 401 && error.response?.data.code === 'INVALID_ACCESS_TOKEN') {
-      if (refreshToken === undefined) {
+    if (error.response?.status === 401 && error.response?.data.error === 'UNAUTHORIZED') {
+      if (!isRefreshing && refreshToken === undefined) {
         console.log('로그인이 다시 필요한 회원');
 
         // accessToken 만료되었는데, refreshToken 없는 경우, storage 비우기
@@ -48,6 +48,13 @@ axiosInstance.interceptors.response.use(
         removeCookie('accessToken');
         removeCookie('refreshToken');
         toasting({ type: 'error', txt: toastMessage.ko.userStatusLoggedOut });
+
+        isRefreshing = true;
+
+        // 토스트 메세지 후 리다이렉트 시키는게 맞는지 확인
+        // setTimeout(() => {
+        //   location.href = '/';
+        // }, 2000);
       }
 
       if (!isRefreshing) {
@@ -73,6 +80,10 @@ axiosInstance.interceptors.response.use(
           removeCookie('accessToken'); // TODO removeCookieAll
           removeCookie('refreshToken');
           toasting({ type: 'error', txt: toastMessage.ko.userStatusLoggedOut });
+
+          // setTimeout(() => {
+          //   location.href = '/';
+          // }, 2000);
         } finally {
           isRefreshing = false;
         }

--- a/src/lib/axios/axiosInstance.ts
+++ b/src/lib/axios/axiosInstance.ts
@@ -1,5 +1,6 @@
-import axios from 'axios';
-import { useUser } from '@/store/useUser';
+import axios, { AxiosRequestConfig } from 'axios';
+// import { useUser } from '@/store/useUser';
+import { getCookie } from '../utils/cookie';
 
 const axiosInstance = axios.create({
   baseURL: 'https://dev.api.listywave.com',
@@ -8,7 +9,11 @@ const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   (config) => {
-    const accessToken = useUser.getState().user.accessToken;
+    // zustande persist에 저장된 토큰 꺼내쓰기 버전 - 방법 1
+    // const accessToken = useUser.getState().user.accessToken;
+
+    // cookie에 저장된 토큰 꺼내쓰기 버전 - 방법 2
+    const accessToken = getCookie('accessToken');
 
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
@@ -21,5 +26,29 @@ axiosInstance.interceptors.request.use(
     return Promise.reject(error);
   }
 );
+
+// interceptors 쿠키로 보내기 버전 - 방법 1
+// axiosInstance.interceptors.response.use(
+//   (res) => res,
+//   async (error) => {
+//     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
+//     if (error.response?.status === 401 && !originalRequest._retry) {
+//       const response = await axiosInstance.get('/auth/token', {
+//         _retry: true,
+//         withCredentials: true,
+//       });
+//       console.log('여기');
+
+//       console.log(response.data);
+
+//       useUser.getState().updateUser({ id: 13, accessToken: response.data.accessToken });
+
+//       originalRequest._retry = true;
+//       axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${response.data.accessToken}`;
+//       return axiosInstance(originalRequest);
+//     }
+//     return Promise.reject(error);
+//   }
+// );
 
 export default axiosInstance;

--- a/src/lib/constants/toastMessage.ts
+++ b/src/lib/constants/toastMessage.ts
@@ -3,6 +3,7 @@ export const MAX_FOLLOWING = 1000;
 const toastMessage = {
   ko: {
     requiredLogin: '로그인이 필요해요.',
+    userStatusLoggedOut: '로그아웃 된 사용자에요. 다시 로그인 해주세요.',
     loggedOut: '로그아웃 되었어요.',
     loggedOutError: '로그아웃에 실패했어요. 다시 시도해주세요.🥲',
     limitFollow: `최대 ${MAX_FOLLOWING.toLocaleString('ko-KR')}명까지 팔로우할 수 있어요.`,
@@ -14,6 +15,7 @@ const toastMessage = {
   },
   en: {
     requiredLogin: 'Login is required.',
+    userStatusLoggedOut: 'You have been logged out. Please log in again.',
     loggedOut: 'Logged out successfully.',
     loggedOutError: 'Failed to log out. Please try again.🥲',
     limitFollow: `Following exceeds the limit of ${MAX_FOLLOWING.toLocaleString('en-US')}.`,

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -11,6 +11,7 @@ export interface UserOnLoginType {
   followingCount: number;
   isFirst: boolean;
   accessToken: string;
+  refreshToken: string;
 }
 
 export interface UserSearchType {

--- a/src/lib/utils/cookie.ts
+++ b/src/lib/utils/cookie.ts
@@ -2,11 +2,11 @@ import { Cookies } from 'react-cookie';
 
 const cookies = new Cookies();
 
-export const setCookie = (name: string, value: string) => {
+export const setCookie = (name: string, value: string, type: 'AT' | 'RT') => {
   return cookies.set(name, value, {
     path: '/',
     secure: true,
-    maxAge: 60 * 2, // 현재 2분 후 토큰 만료되고, 자동사라짐
+    maxAge: type === 'AT' ? 60 * 10 : 60 * 60 * 24, // 현재 refreshToken 쿠키로 전달 도입 전까지, AT는 만료 시간 2분, RT는 24시간으로 설정
   });
 };
 

--- a/src/lib/utils/cookie.ts
+++ b/src/lib/utils/cookie.ts
@@ -1,0 +1,35 @@
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+export const setCookie = (name: string, value: string) => {
+  return cookies.set(name, value, {
+    path: '/',
+    secure: true,
+    maxAge: 60 * 2, // 현재 2분 후 토큰 만료되고, 자동사라짐
+  });
+};
+
+export const getCookie = (name: string) => {
+  return cookies.get(name);
+};
+
+export const removeCookie = (name: string) => {
+  return cookies.remove(name, { path: '/' });
+};
+
+// server 컴포넌트에서 쿠키읽기 - 참고용으로 작성 후 주석처리 해둠
+
+// 'use server'
+
+// import { cookies } from 'next/headers';
+
+// export const setCookie = (accessToken: string) => {
+//   cookies().set({
+//     name: 'accessToken',
+//     value: accessToken,
+//     secure: true,
+//     path: '/',
+//     maxAge: 60 * 2,
+//   });
+// };

--- a/src/lib/utils/cookie.ts
+++ b/src/lib/utils/cookie.ts
@@ -6,7 +6,7 @@ export const setCookie = (name: string, value: string, type: 'AT' | 'RT') => {
   return cookies.set(name, value, {
     path: '/',
     secure: true,
-    maxAge: type === 'AT' ? 60 * 10 : 60 * 60 * 24, // 현재 refreshToken 쿠키로 전달 도입 전까지, AT는 만료 시간 2분, RT는 24시간으로 설정
+    maxAge: type === 'AT' ? 60 * 30 : 60 * 60 * 24, // 현재 refreshToken 쿠키로 전달 도입 전까지, AT는 만료 시간 30분, RT는 24시간으로 설정
   });
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+// 쿠키에 저장된 정보를 확인하여 권한에 따른 분기처리 로직(서버에서 실행)
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getCookie } from './lib/utils/cookie';
+
+const REQUIRED_TOKEN = ['/account', '/start-listy', '/list/create', '/collection', '/notification'];
+
+export function middleware(request: NextRequest) {
+  // 만약, 쿠키에 accessToken이 없다면 '/'페이지로 리다이렉트
+  const accessToken = getCookie('accessToken');
+
+  if (!accessToken && REQUIRED_TOKEN.includes(request.nextUrl.pathname)) {
+    return NextResponse.rewrite(new URL('/login', request.url));
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,8 +8,12 @@ const REQUIRED_TOKEN = ['/account', '/start-listy', '/list/create', '/collection
 export async function middleware(request: NextRequest) {
   // 만약, 쿠키에 accessToken이 없다면 '/'페이지로 리다이렉트
   const accessToken = request.cookies.get('accessToken');
+  console.log(!accessToken);
 
-  if (!accessToken && REQUIRED_TOKEN.includes(request.nextUrl.pathname)) {
+  // '/account'로 시작하는 하위 URL 포함 조건 추가
+  const isAccountSubPath = request.nextUrl.pathname.startsWith('/account');
+
+  if (!accessToken && (REQUIRED_TOKEN.includes(request.nextUrl.pathname) || isAccountSubPath)) {
     const url = new URL('/', request.url);
     url.searchParams.set('loginRequired', 'true'); // 쿼리 파라미터 추가
     return NextResponse.redirect(url);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,6 +11,8 @@ export function middleware(request: NextRequest) {
   const accessToken = getCookie('accessToken');
 
   if (!accessToken && REQUIRED_TOKEN.includes(request.nextUrl.pathname)) {
-    return NextResponse.rewrite(new URL('/login', request.url));
+    const url = new URL('/', request.url);
+    url.searchParams.set('loginRequired', 'true'); // 쿼리 파라미터 추가
+    return NextResponse.redirect(url);
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,13 +2,12 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { getCookie } from './lib/utils/cookie';
 
 const REQUIRED_TOKEN = ['/account', '/start-listy', '/list/create', '/collection', '/notification'];
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   // 만약, 쿠키에 accessToken이 없다면 '/'페이지로 리다이렉트
-  const accessToken = getCookie('accessToken');
+  const accessToken = request.cookies.get('accessToken');
 
   if (!accessToken && REQUIRED_TOKEN.includes(request.nextUrl.pathname)) {
     const url = new URL('/', request.url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,6 +3052,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -3105,7 +3110,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hoist-non-react-statics@^3.3.0":
+"@types/hoist-non-react-statics@^3.3.0", "@types/hoist-non-react-statics@^3.3.5":
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
   integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
@@ -4926,6 +4931,11 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookie@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
+  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
 copy-to-clipboard@^3.3.3:
   version "3.3.3"
@@ -10628,6 +10638,15 @@ react-beautiful-dnd@^13.1.1:
     redux "^4.0.4"
     use-memo-one "^1.1.1"
 
+react-cookie@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-7.0.2.tgz#a0bf09c44bdb1955e02d442511fa9512062cb81a"
+  integrity sha512-UnW1rZw1VibRdTvV8Ksr0BKKZoajeUxYLE89sIygDeyQgtz6ik89RHOM+3kib36G9M7HxheORggPoLk5DxAK7Q==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.5"
+    hoist-non-react-statics "^3.3.2"
+    universal-cookie "^7.0.0"
+
 react-dev-utils@^12.0.1:
   version "12.0.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-12.0.1.tgz#ba92edb4a1f379bd46ccd6bcd4e7bc398df33e73"
@@ -12407,6 +12426,14 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+universal-cookie@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-7.0.2.tgz#490221c790bc13694347340a758ac65adbaa30b8"
+  integrity sha512-EC9PA+1nojhJtVnKW2Z7WYah01jgYJApqhX+Y8XU97TnFd7KaoxWTHiTZFtfpfV50jEF1L8V5p64ZxIx3Q67dg==
+  dependencies:
+    "@types/cookie" "^0.6.0"
+    cookie "^0.6.0"
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## 개요

- refreshToken(RT)로 만료된 accessToken(AT)를 재발급 받는 기능을 구현했습니다.

<br>

## 작업 사항

- 기존 로컬스토리지에 저장한 AT를 리액트 쿠키를 사용하여 쿠키에 저장하는 것으로 변경하였습니다.
- 미들웨어를 추가하여 페이지 접근 권한 처리를 하였습니다.
- axios interceptors로 api 요청 시 토큰 만료된 경우에 대한 에러 핸들링을 하였습니다.
  - [x] RT가 있고, AT가 만료된 경우 -> 토큰 갱신 후 처리
  - [x] RT가 있고, AT가 없는 경우 -> 토큰 갱신 후 처리
  - [x] RT가 없고, AT가 만료된 경우 -> 로그아웃 시키고, 토스트 메세지
  - [x] AT, RT 토큰 모두 없는데 권한 필요한 경우 -> 로그아웃 시키고, 토스트 메세지
- 탈퇴한 회원에 대해 로그인 시 탈퇴페이지로 리다이렉트 처리를 추가하였습니다.
- 공통 바텀 네비게이션 컴포넌트에서 마이피드 접근 시, 비회원인 경우 토스트 메세지를 추가하였습니다.
- 쿠키 만료시간을 AT는 30분, RT는 24시간으로 설정하였습니다.
  - [  ] 이 부분은 추후 처음에 RT를 받을 때 쿠키로 받는 로직으로 변경 될 예정이기 때문에, 그 전까지 관리를 위해 설정하였습니다.
  - 즉, 24시간마다는 로그인이 필요합니다.

<br>

## 참고 사항 (optional)

- 추후 작성하여 첨부하겠습니다.

<br>

## 관련 이슈 (optional)

- 추후 작성하여 첨부하겠습니다.

<br>

## 스크린샷

- 추후 작성하여 첨부하겠습니다.

<br>

## 리뷰어에게

- 늦게 올려서 죄송합니다!! 테스트 하면서 추가로 에러 핸들링 할 부분이 발생할 것 같아서 계속 보완해나가겠습니다. 감사합니다.

<br>
