### PR TITLE
Refactor: 리스트  수정, 생성   페이지는 히스토리 기록에 남지 않도록 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,9 @@ export default function TempLayout({ children }: { children: ReactNode }) {
   const { isOn, handleSetOff } = useModalState();
 
   function kakaoInit() {
-    window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_API_KEY);
+    if (!window.Kakao.isInitialized()) {
+      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_API_KEY);
+    }
     console.log('kakaoShareStatus:', window.Kakao.isInitialized());
   }
 
@@ -34,8 +36,7 @@ export default function TempLayout({ children }: { children: ReactNode }) {
         <title>ListyWave</title>
         <meta
           name="viewport"
-          content="width=device-width, initial-scale=1, maximum-scale=1.0, 
-    user-scalable=0"
+          content="width=device-width; initial-scale=1.0; maximum-scale=1.0; minimum-scale=1.0; user-scalable=no viewport-fit=cover"
         />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
         <Script

--- a/src/app/list/[listId]/edit/page.tsx
+++ b/src/app/list/[listId]/edit/page.tsx
@@ -138,7 +138,7 @@ export default function EditPage() {
   } = useMutation({
     mutationFn: updateList,
     onSettled: () => {
-      router.push(`/user/${owner.id}/list/${param?.listId}`);
+      router.replace(`/list/${param?.listId}`);
     },
   });
 

--- a/src/app/list/create/page.tsx
+++ b/src/app/list/create/page.tsx
@@ -122,7 +122,7 @@ export default function CreatePage() {
           imageFileList: formatData().imageFileList,
         });
       }
-      router.push(`/list/${data.listId}`);
+      router.replace(`/list/${data.listId}`);
     },
     onError: () => {
       toasting({ type: 'error', txt: toastMessage.ko.createListError });


### PR DESCRIPTION
## 개요

- 리스트 생성, 수정 완료 후 상세페이지 이동시, 리스트 생성/수정의 히스토리가 남지 않는다

<br>

## 작업 사항
- router.push 대신 router.replace로 이동
- layout 일부 코드를 살짝 수정했습니다.

## 리뷰어에게

- 파이팅!

<br>
