### PR TITLE
Refactor: 아코디언 default 열림 상태, 메타 태그 재설정, 버튼 뒷 배경 없애기 재시도

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
+import type { Viewport } from 'next';
 import { ToastContainer } from 'react-toastify';
 import Script from 'next/script';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -20,6 +21,15 @@ declare global {
     Kakao: any;
   }
 }
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
+};
+
 export default function TempLayout({ children }: { children: ReactNode }) {
   const { isOn, handleSetOff } = useModalState();
 
@@ -34,10 +44,6 @@ export default function TempLayout({ children }: { children: ReactNode }) {
     <html lang="ko">
       <head>
         <title>ListyWave</title>
-        <meta
-          name="viewport"
-          content="width=device-width; initial-scale=1.0; maximum-scale=1.0; minimum-scale=1.0; user-scalable=no viewport-fit=cover"
-        />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
         <Script
           src="https://t1.kakaocdn.net/kakao_js_sdk/2.6.0/kakao.min.js"

--- a/src/app/list/create/_components/item/ItemLayout.tsx
+++ b/src/app/list/create/_components/item/ItemLayout.tsx
@@ -40,7 +40,7 @@ export default function ItemLayout({
   return (
     <div>
       {titleErrorMessage && <p className={styles.titleError}> {titleErrorMessage}</p>}
-      <Accordion>
+      <Accordion defaultExpanded={true}>
         <AccordionSummary>
           <div className={styles.itemHeader}>
             <DndIcon width="18" height="18" alt="드래그앤드롭" className={styles.headerIcon} />

--- a/src/styles/GlobalStyles.css.ts
+++ b/src/styles/GlobalStyles.css.ts
@@ -11,6 +11,7 @@ globalStyle('html', {
 globalStyle('body *', {
   boxSizing: 'border-box',
   fontFamily: Pretendard,
+  WebkitTapHighlightColor: 'rgba(0,0,0,0) !important',
 });
 
 globalStyle('body, div, span, h1, h2, h3, h4, h5, h6, p, a, dl, dt, dd, ol, ul, li, form, label, table, button', {
@@ -34,7 +35,7 @@ globalStyle('button', {
   cursor: 'pointer',
   color: vars.color.black,
   backgroundColor: 'transparent',
-  WebkitTapHighlightColor: 'rgba(0,0,0,0)',
+  WebkitTapHighlightColor: 'rgba(0,0,0,0) !important',
 });
 
 globalStyle('input', {


### PR DESCRIPTION
## 개요

- 여러 UX 불편 사항 개선 작업 진행

<br>

## 작업 사항

- 리스트 생성 아이템의 아코디언 UI 열림 상태를 default로 수정
- 메타 태그 설정 방법을 다르게 했습니다.
- 버튼 뒷배경 없애는 코드에 important를 줬습니다.
