### PR TITLE
Feat: 프로필 이미지 공용컴포넌트 - onError 이용해 이미지 로드 실패 처리

### DIFF
--- a/src/components/UserProfileImage/UserProfileImage.tsx
+++ b/src/components/UserProfileImage/UserProfileImage.tsx
@@ -1,35 +1,22 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
 
-import DefaultProfile from '/public/icons/default_profile.svg';
-import axiosInstance from '@/lib/axios/axiosInstance';
 import * as styles from './UserProfileImage.css';
-import axios from 'axios';
 
 function UserProfileImage({ src, size }: { src: string; size: number }) {
   const [isValidImage, setIsValidImage] = useState(false);
 
-  useEffect(() => {
-    const handleFetchImage = async () => {
-      if (!src) {
+  return (
+    <Image
+      className={styles.profileImage}
+      src={isValidImage ? src : '/icons/default_profile.svg'}
+      width={size}
+      height={size}
+      alt="이미지 프로필"
+      onError={() => {
         setIsValidImage(false);
-        return;
-      }
-      try {
-        await axios.get(src);
-      } catch (error) {
-        setIsValidImage(false);
-        return;
-      }
-      setIsValidImage(true);
-    };
-    handleFetchImage();
-  }, []);
-
-  return isValidImage ? (
-    <Image className={styles.profileImage} src={src} width={size} height={size} alt="이미지 프로필" />
-  ) : (
-    <DefaultProfile width={size} height={size} />
+      }}
+    />
   );
 }
 


### PR DESCRIPTION
## 개요

- 프로필 이미지 로드 실패시 보여지는 공용 프로필 컴포넌트
- 로드 실패 판단 방법을 fetch로 먼저 테스트해보는 방식에서 next/Image onError 를 이용하는 방식으로 바꿨습니다.
