### PR TITLE
Fix: 히스토리 페이지 헤더 상단 고정 안 됨 이슈 해결

### DIFF
--- a/src/app/list/[listId]/history/page.css.ts
+++ b/src/app/list/[listId]/history/page.css.ts
@@ -2,10 +2,9 @@ import { style, styleVariants, keyframes } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 import * as fonts from '@/styles/font.css';
 
-export const container = style({ overflowY: 'hidden' });
-
 export const navContainer = style({
   width: '100%',
+
   padding: '18px 65.5px 0',
   margin: '0 auto',
 
@@ -17,6 +16,8 @@ export const navContainer = style({
   top: '70px',
 
   backgroundColor: vars.color.white,
+
+  zIndex: '1',
 });
 
 export const navButton = style([

--- a/src/app/list/[listId]/history/page.tsx
+++ b/src/app/list/[listId]/history/page.tsx
@@ -36,35 +36,35 @@ function HistoryPage() {
   });
 
   return (
-    <div className={styles.container}>
+    <>
       <Header
         title={listLocale[language].history}
         left="back"
         leftClick={() => {
           router.back();
         }}
-        right={<div></div>}
       />
+      <div>
+        <div className={styles.navContainer}>
+          <button className={styles.navButton} onClick={() => setType('graph')}>
+            {listLocale[language].graph}
+          </button>
+          <button className={styles.navButton} onClick={() => setType('version')}>
+            {listLocale[language].version}
+          </button>
+          <div className={type === 'graph' ? styles.navBar.left : styles.navBar.right} />
+        </div>
 
-      <div className={styles.navContainer}>
-        <button className={styles.navButton} onClick={() => setType('graph')}>
-          {listLocale[language].graph}
-        </button>
-        <button className={styles.navButton} onClick={() => setType('version')}>
-          {listLocale[language].version}
-        </button>
-        <div className={type === 'graph' ? styles.navBar.left : styles.navBar.right} />
+        <div className={styles.listTitle}>{listData?.title}</div>
+        <div className={styles.contentContainer}>
+          {type === 'graph' ? (
+            <Graph histories={historyData ? historyData : []} />
+          ) : (
+            <Version histories={historyData ? historyData : []} listId={listId} listOwnerId={listData?.ownerId} />
+          )}
+        </div>
       </div>
-
-      <div className={styles.listTitle}>{listData?.title}</div>
-      <div className={styles.contentContainer}>
-        {type === 'graph' ? (
-          <Graph histories={historyData ? historyData : []} />
-        ) : (
-          <Version histories={historyData ? historyData : []} listId={listId} listOwnerId={listData?.ownerId} />
-        )}
-      </div>
-    </div>
+    </>
   );
 }
 export default HistoryPage;


### PR DESCRIPTION
## 개요

- 히스토리 페이지에서 사용한 공용헤더만 position: sticky가 적용되지 않아 상단 고정 되고 있지 않던 이슈를 해결했습니다.

<br>

## 참고 사항 

- position: sticky 는 body 태그 처럼 height가 지정된 부모를 가져야하고 부모태그에 overflow 속성이 없어야만 적용됩니다.

<br>
