### PR TITLE
Fix: 리스트 전체 조회 api 필드 값 변경으로 인한 타입, 쿼리 프로퍼티 수정

### DIFF
--- a/src/app/_api/list/getAllList.ts
+++ b/src/app/_api/list/getAllList.ts
@@ -1,15 +1,15 @@
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { AllListType } from '@/lib/types/listType';
 
-const getAllList = async (userId: number, type: string, category: string, cursorId?: number) => {
+const getAllList = async (userId: number, type: string, category: string, cursorUpdatedDate?: string) => {
   const params = new URLSearchParams({
     type,
     category,
     size: '10',
   });
 
-  if (cursorId) {
-    params.append('cursorId', cursorId.toString());
+  if (cursorUpdatedDate) {
+    params.append('cursorUpdatedDate', cursorUpdatedDate.toString());
   }
 
   const response = await axiosInstance.get<AllListType>(`/users/${userId}/lists?${params.toString()}`);

--- a/src/app/user/[userId]/_components/Content.tsx
+++ b/src/app/user/[userId]/_components/Content.tsx
@@ -44,11 +44,11 @@ export default function Content({ userId, type }: ContentProps) {
     isLoading,
   } = useInfiniteQuery<AllListType>({
     queryKey: [QUERY_KEYS.getAllList, userId, type, selectedCategory],
-    queryFn: ({ pageParam: cursorId }) => {
-      return getAllList(userId, type, selectedCategory, cursorId as number);
+    queryFn: ({ pageParam: cursorUpdatedDate }) => {
+      return getAllList(userId, type, selectedCategory, cursorUpdatedDate as string);
     },
     initialPageParam: null,
-    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.cursorId : null),
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.cursorUpdatedDate : null),
   });
 
   const lists = useMemo(() => {

--- a/src/lib/types/listType.ts
+++ b/src/lib/types/listType.ts
@@ -63,7 +63,7 @@ export interface LabelType {
 
 // 리스트 전체 조회 타입
 export interface AllListType {
-  cursorId: number;
+  cursorUpdatedDate: string;
   hasNext: boolean;
   feedLists: ListType[];
 }


### PR DESCRIPTION
## 개요

- 리스트 전체 조회 api 필드 값 변경으로 인한 타입, 쿼리 프로퍼티 수정

<br>

## 작업 사항

- 리스트 전체 조회 cursorId 값이 기존 리스트 고유 id 값에서 리스트 업데이트 값으로 변경
  ㄴ 그 이유는, 트랜딩, 검색페이지 등 리스트를 최신순으로 유지해야 하는데 id값으로 정렬하면 리스트 수정 등이 발생했을 때 리스트 목록이 중간중간 비는 현상 발생
  ㄴ 리스트 전체 관리를 위해 리스트 관련 고유값을 cursorUpdatedDate으로 변경
- api 파라미터, 리스폰스 타입, 리액트 쿼리 파라미터를 수정

<br>

## 참고 사항 (optional)

<br>

## 관련 이슈 (optional)

<br>

## 스크린샷

<br>

## 리뷰어에게

- 어떤 부분에 리뷰어가 집중하면 좋을지

<br>
