### PR TITLE
히스토리 페이지 - 순위 float로 표시되던 순위를 int로 변경 및 순위 기준 정렬

### DIFF
--- a/src/app/list/[listId]/history/_component/HistoryGraph.tsx
+++ b/src/app/list/[listId]/history/_component/HistoryGraph.tsx
@@ -60,6 +60,7 @@ interface Option {
     categories: number[];
     reversed: boolean;
     stepSize: number;
+    labels: { formatter: (val: number) => string };
   };
   grid: {
     padding: {
@@ -104,9 +105,14 @@ export function Chart({ histories, itemRankHistories }: ChartProps) {
       type: 'category',
     },
     yaxis: {
-      categories: Array.from({ length: 10 }, (_, index) => 10 - index),
+      categories: Array.from({ length: 10 }, (_, index) => Math.round(10 - index)),
       reversed: true,
       stepSize: 1,
+      labels: {
+        formatter: (val: number) => {
+          return `${val.toFixed(0)}위`;
+        },
+      },
     },
     grid: {
       padding: {

--- a/src/app/list/[listId]/history/_component/HistoryVersions.tsx
+++ b/src/app/list/[listId]/history/_component/HistoryVersions.tsx
@@ -130,7 +130,9 @@ function HistoryVersions({ histories, listId, listOwnerId }: VersionHistoryProps
                   {timeDiff(String(selectedHistory?.createdDate))}
                 </div>
                 <div className={styles.itemsContainer}>
-                  {selectedHistory?.items.map((item) => <Item key={item.id} rank={item.rank} title={item.title} />)}
+                  {selectedHistory?.items
+                    .sort((a, b) => a.rank - b.rank)
+                    .map((item) => <Item key={item.id} rank={item.rank} title={item.title} />)}
                 </div>
               </>
             ) : (

--- a/src/app/list/[listId]/history/page.css.ts
+++ b/src/app/list/[listId]/history/page.css.ts
@@ -2,10 +2,9 @@ import { style, styleVariants, keyframes } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 import * as fonts from '@/styles/font.css';
 
-export const container = style({ overflowY: 'hidden' });
-
 export const navContainer = style({
   width: '100%',
+
   padding: '18px 65.5px 0',
   margin: '0 auto',
 
@@ -17,6 +16,8 @@ export const navContainer = style({
   top: '70px',
 
   backgroundColor: vars.color.white,
+
+  zIndex: '1',
 });
 
 export const navButton = style([

--- a/src/app/list/[listId]/history/page.tsx
+++ b/src/app/list/[listId]/history/page.tsx
@@ -36,35 +36,35 @@ function HistoryPage() {
   });
 
   return (
-    <div className={styles.container}>
+    <>
       <Header
         title={listLocale[language].history}
         left="back"
         leftClick={() => {
           router.back();
         }}
-        right={<div></div>}
       />
+      <div>
+        <div className={styles.navContainer}>
+          <button className={styles.navButton} onClick={() => setType('graph')}>
+            {listLocale[language].graph}
+          </button>
+          <button className={styles.navButton} onClick={() => setType('version')}>
+            {listLocale[language].version}
+          </button>
+          <div className={type === 'graph' ? styles.navBar.left : styles.navBar.right} />
+        </div>
 
-      <div className={styles.navContainer}>
-        <button className={styles.navButton} onClick={() => setType('graph')}>
-          {listLocale[language].graph}
-        </button>
-        <button className={styles.navButton} onClick={() => setType('version')}>
-          {listLocale[language].version}
-        </button>
-        <div className={type === 'graph' ? styles.navBar.left : styles.navBar.right} />
+        <div className={styles.listTitle}>{listData?.title}</div>
+        <div className={styles.contentContainer}>
+          {type === 'graph' ? (
+            <Graph histories={historyData ? historyData : []} />
+          ) : (
+            <Version histories={historyData ? historyData : []} listId={listId} listOwnerId={listData?.ownerId} />
+          )}
+        </div>
       </div>
-
-      <div className={styles.listTitle}>{listData?.title}</div>
-      <div className={styles.contentContainer}>
-        {type === 'graph' ? (
-          <Graph histories={historyData ? historyData : []} />
-        ) : (
-          <Version histories={historyData ? historyData : []} listId={listId} listOwnerId={listData?.ownerId} />
-        )}
-      </div>
-    </div>
+    </>
   );
 }
 export default HistoryPage;


### PR DESCRIPTION
## 개요

- 히스토리 페이지에서 순위가 1.0위 처럼 float로 표시되었는데 순위를 int로 변경했습니다.
- 히스토리 버전 페이지에서 순위 기준 정렬로 보여지게 했습니다.