### PR TITLE
Fix: 리스트 수정 - 콜라보레이터가 1명 이상일때 owner ID 포함시켜 API 호출로 변경

### DIFF
--- a/src/app/list/[listId]/edit/page.tsx
+++ b/src/app/list/[listId]/edit/page.tsx
@@ -62,6 +62,7 @@ export default function EditPage() {
     //데이터 쪼개기
     const listData: ListEditType = {
       ...originData,
+      collaboratorIds: originData.collaboratorIds.length === 0 ? [] : [...originData.collaboratorIds, user.id],
       items: originData.items.map(({ imageUrl, ...rest }) => {
         if (typeof imageUrl === 'string') {
           return {

--- a/src/lib/types/listType.ts
+++ b/src/lib/types/listType.ts
@@ -25,7 +25,7 @@ export interface ListCreateType {
 export interface ListEditType {
   category: string;
   labels: string[];
-  collaboratorIds: number[];
+  collaboratorIds: (number | null)[];
   title: string;
   description: string;
   isPublic: boolean;


### PR DESCRIPTION
## 개요

- 리스트 수정시 콜라보레이터가 1명 이상일때 owner ID 포함시켜 API 호출, 콜라보레이터가 0명일때는 빈배열로 API 호출로 변경