### PR TITLE
Fix : 리스트상세 이미지 및 리스트의 타입 초기값을 detail로 변경

### DIFF
--- a/src/app/list/[listId]/_components/ListDetailInner/Header.tsx
+++ b/src/app/list/[listId]/_components/ListDetailInner/Header.tsx
@@ -29,7 +29,7 @@ function Header({ handleChangeListType }: HeaderProps) {
   return (
     <div className={styles.container}>
       <SelectComponent
-        defaultValue={dropdownOptions[0]}
+        defaultValue={dropdownOptions[1]}
         name="listType"
         options={dropdownOptions}
         isSearchable={false}

--- a/src/app/list/[listId]/_components/ListDetailInner/RankList.css.ts
+++ b/src/app/list/[listId]/_components/ListDetailInner/RankList.css.ts
@@ -160,8 +160,8 @@ export const simpleImageWrapper = style({
 });
 
 export const detailImageWrapper = style({
-  width: '100%',
-  height: '35rem',
+  // width: '100%',
+  height: 'fit-content',
 
   position: 'relative',
 
@@ -185,7 +185,7 @@ export const simpleImage = style({
 export const detailImage = style({
   width: '100%',
   maxHeight: '35rem',
-  height: 'auto',
+  height: 'fit-content',
 
   border: `1px solid ${vars.color.gray5}`,
   borderRadius: '10px',

--- a/src/app/list/[listId]/_components/ListDetailInner/RankList.tsx
+++ b/src/app/list/[listId]/_components/ListDetailInner/RankList.tsx
@@ -95,7 +95,7 @@ function DetailList({ listData }: RankListProps) {
 
         {item.imageUrl && (
           <div className={styles.detailImageWrapper}>
-            <Image className={styles.detailImage} src={item.imageUrl} alt={item.title} fill={true} />
+            <img className={styles.detailImage} src={item.imageUrl} alt={item.title} />
           </div>
         )}
 

--- a/src/app/list/[listId]/_components/ListDetailInner/index.tsx
+++ b/src/app/list/[listId]/_components/ListDetailInner/index.tsx
@@ -21,7 +21,7 @@ interface ListDetailInnerProps {
 
 function ListDetailInner({ data, listId }: ListDetailInnerProps) {
   const listData = data?.items;
-  const [listType, setListType] = useState('simple');
+  const [listType, setListType] = useState('detail');
 
   const handleChangeListType = (target: OptionsProps) => {
     const value: string = target.value;


### PR DESCRIPTION
## 개요

- 개요는 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.
- 해당 PR에 대한 리뷰어와 라벨을 생성해 주세요.

<br>

## 작업 사항

- 리스트 상세 이미지를 img태그로 변경했습니다.
( next/Image 태그를 사용할경우 높이지정이 되지않는 문제가 있었습니다. 추후 수정하겠습니다.)
- 리스트상세페이지의 초기값을 detail로 변경했습니다.

