### PR TITLE
Fix: 콜렉션, 마이페이지, 탈퇴하기, 프로필 설정 오류 해결

### DIFF
--- a/public/icons/folder_food.svg
+++ b/public/icons/folder_food.svg
@@ -1,0 +1,1 @@
+<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 118"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 0A15 15 0 0 0 0 15v80.9a15 15 0 0 0 15 15h52.3a15 15 0 0 0 14.1-9.9H145a15 15 0 0 0 15-15V27.6a15 15 0 0 0-15-15H79A25 25 0 0 0 57.3 0H15Z" fill="#FFBEBE"/><rect y="20.9" width="160" height="96.4" rx="15" fill="#FFF9E3"/></svg>

--- a/src/app/account/_components/LanguageDropdown.tsx
+++ b/src/app/account/_components/LanguageDropdown.tsx
@@ -28,7 +28,7 @@ export default function LanguageDropdown() {
               handleSelectLanguage('ko');
             }}
           >
-            accountLocale[language].korean
+            {accountLocale[language].korean}
           </div>
           <div
             className={`${styles.listDiv} ${language === 'en' && styles.selected}`}

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -35,7 +35,6 @@ export default function AccountPage() {
           router.back();
         }}
         title={accountLocale[language].myPage}
-        right={<div />} //TODO: 공용HEADER 수정후 DIV없애기
       />
       <section className={styles.container}>
         <div className={styles.buttonDiv} onClick={onClickMoveToPage('account/profile')} role="button">
@@ -62,7 +61,12 @@ export default function AccountPage() {
             {accountLocale[language].contact}
           </div>
         </div>
-        <div className={styles.buttonDiv}>
+        <div
+          className={styles.buttonDiv}
+          onClick={() => {
+            handleDivLinkClick('https://tally.so/r/w51Dpv');
+          }}
+        >
           <div className={styles.titleDiv}>
             <MessageIcon width={24} height={24} alt={accountLocale[language].sendFeedback} />
             {accountLocale[language].sendFeedback}

--- a/src/app/account/profile/page.tsx
+++ b/src/app/account/profile/page.tsx
@@ -107,7 +107,10 @@ export default function ProfilePage() {
               router.back();
             }}
             right={
-              <BlueButton type="submit" disabled={!methods.formState.isDirty || isPending}>
+              <BlueButton
+                type="submit"
+                disabled={!methods.formState.isDirty || !methods.formState.isValid || isPending}
+              >
                 {accountLocale[language].save}
               </BlueButton>
             }

--- a/src/app/account/withdraw/_component/WithdrawalHeader.tsx
+++ b/src/app/account/withdraw/_component/WithdrawalHeader.tsx
@@ -1,17 +1,19 @@
 'use client';
+import { useRouter } from 'next/navigation';
 import Header from '@/components/Header/Header';
-import useMoveToPage from '@/hooks/useMoveToPage';
 import { accountLocale } from '@/app/account/locale';
 import { useLanguage } from '@/store/useLanguage';
 
 export default function WithdrawalHeader() {
   const { language } = useLanguage();
-  const { onClickMoveToPage } = useMoveToPage();
+  const router = useRouter();
   return (
     <Header
       title={accountLocale[language].withdrawal}
       left="back"
-      leftClick={onClickMoveToPage('/account')}
+      leftClick={() => {
+        router.back();
+      }}
       right={<div />}
     />
   );

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -18,6 +18,7 @@ import MovieDramaFolder from '/public/icons/folder_movie_drama.svg';
 import AnimalPlantFolder from '/public/icons/folder_animal_plant.svg';
 import EtcFolder from '/public/icons/folder_etc.svg';
 import BookFolder from '/public/icons/folder_book.svg';
+import FoodFolder from '/public/icons/folder_food.svg';
 
 import getCollectionCategories from '../_api/collect/getCollectionCategories';
 
@@ -44,7 +45,7 @@ const codeToFolderIcon = (code: string) => {
     case '8':
       return <EtcFolder fill alt="기타 카테고리" />;
     case '9':
-      return <EntireFolder fill alt="음식 카테고리" />; //TODO: 폴더 이미지 바꾸기
+      return <FoodFolder fill alt="음식 카테고리" />;
   }
 };
 


### PR DESCRIPTION
## 개요
- 자잘한 오류를 해결했습니다.

<br>

## 작업 사항
- 콜렉션  페이지에  추가된 '음식' 카테고리의 폴더 이미지를  추가했습니다.
- 마이페이지에 언어선택 '한국어' 표시를 수정했습니다.
- 마이페이지 '의견 보내기' 버튼에 설문 링크를  추가했습니다.
- 탈퇴하기 페이지 헤더 뒤로가기 버튼에 '링크 이동'이 아닌 '뒤로가기' 동작을 추가했습니다.
- 프로필 설정시 input에 에러가 있어도 버튼이 활성화 되는 것을 막았습니다.

<br>

## 리뷰어에게

- '의견보내기'에 우선 tally로 간단하게 설문 만들어 연결해두었습니다! 추후 공용 지메일로 설문 제대로 만들어보아요~!