### PR TITLE
HOTFIX: 프로필 설정 '저장'버튼 비활성화 오류 해결

### DIFF
--- a/src/app/account/profile/page.tsx
+++ b/src/app/account/profile/page.tsx
@@ -95,7 +95,6 @@ export default function ProfilePage() {
   const handleFormSubmit = () => {
     updateProfileMutate({ userId: user.id as number, data: methods.getValues() });
   };
-
   return (
     <>
       <FormProvider {...methods}>
@@ -109,7 +108,12 @@ export default function ProfilePage() {
             right={
               <BlueButton
                 type="submit"
-                disabled={!methods.formState.isDirty || !methods.formState.isValid || isPending}
+                disabled={
+                  !methods.formState.isDirty ||
+                  !!methods.formState.errors.nickname ||
+                  !!methods.formState.errors.description ||
+                  isPending
+                }
               >
                 {accountLocale[language].save}
               </BlueButton>


### PR DESCRIPTION
## 개요
- 프로필 이미지가 바뀌어도 저장 버튼이 활성화 되지 않는 이슈를 해결합니다.

<br>

## 작업 사항
- 비활성화 조건 수정
