### PR TITLE
Fix: 검색페이지 배포 시, 무한렌더링 이슈 해결을 위한 useEffect문 주석 처리 시도

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -23,12 +23,12 @@ export default function Search() {
   const [category, setCategory] = useState('');
   const [sort, setSort] = useState('');
 
-  useEffect(() => {
-    // 페이지 첫 로드시 검색어와 카테고리 설정
-    setKeyword(searchParams?.get('keyword') ?? '');
-    setCategory(searchParams?.get('category') ?? 'entire');
-    setSort(searchParams?.get('sort') ?? 'new');
-  }, [searchParams]);
+  // useEffect(() => {
+  //   // 페이지 첫 로드시 검색어와 카테고리 설정
+  //   setKeyword(searchParams?.get('keyword') ?? '');
+  //   setCategory(searchParams?.get('category') ?? 'entire');
+  //   setSort(searchParams?.get('sort') ?? 'new');
+  // }, [searchParams]);
 
   const handleKeywordChange = (e: ChangeEvent<HTMLInputElement>) => {
     setKeyword(e.target.value);


### PR DESCRIPTION
## 개요

- 배포 버전에서 발생하는 검색페이지 진입 시 무한렌더링 이슈 해결 시도

<br>

## 작업 사항

- /search/page.tsx 에서 useEffect문 주석 처리

<br>

## 참고 사항 (optional)

- 정확히 어느 부분이 문제인지 개발 버전에서 확인이 어려워 우선 페이지 useEffect문을 주석처리 해 보았습니다.

<br>

## 리뷰어에게

- 현지님, 우선 오류를 빨리 해결해야 할 것 같아서 1차 시도를 해보았습니다. 참고 부탁드립니다.🥲
- 만약 해당 pr 머지 후 무한렌더링이 해결된다면, 그 이후 관련기능에 대해서는 현지님께서 확인 부탁드립니다!!

<br>
