### PR TITLE
feat: 구글태그매니저(gtm) 스니펫 삽입

### DIFF
--- a/src/app/intro/_components/Footer.tsx
+++ b/src/app/intro/_components/Footer.tsx
@@ -21,7 +21,7 @@ function Footer() {
     <>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="introLoginBtn" />
         </Modal>
       )}
       <section className={styles.background}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,7 @@
 import { ReactNode } from 'react';
 import type { Metadata, Viewport } from 'next';
 import { ToastContainer } from 'react-toastify';
-import { GoogleAnalytics } from '@next/third-parties/google';
-import * as gtag from '@/lib/utils/gtag';
-import { GtmScript, GtmNoScript } from '@/lib/utils/gtag';
+import { GtmScript, GtmNoScript } from '@/lib/utils/gtm';
 
 import BottomNav from '@/components/BottomNav/BottomNav';
 
@@ -64,7 +62,6 @@ export default function Layout({ children }: { children: ReactNode }) {
           </div>
           <ToastContainer className={styles.toastContainer} />
         </CommonProvider>
-        <GoogleAnalytics gaId={`${gtag.GA_TRACKING_ID}`} />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,6 +55,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         <link rel="apple-touch-icon" href="https://image.listywave.com/favicon/favicon.png" />
       </head>
       <body className={styles.body}>
+        <GtmNoScript />
         <CommonProvider>
           <div id="modal-root" />
           <div>
@@ -65,7 +66,6 @@ export default function Layout({ children }: { children: ReactNode }) {
         </CommonProvider>
         <GoogleAnalytics gaId={`${gtag.GA_TRACKING_ID}`} />
       </body>
-      <GtmNoScript />
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata, Viewport } from 'next';
 import { ToastContainer } from 'react-toastify';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import * as gtag from '@/lib/utils/gtag';
+import { GtmScript, GtmNoScript } from '@/lib/utils/gtag';
 
 import BottomNav from '@/components/BottomNav/BottomNav';
 
@@ -48,6 +49,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="ko">
       <head>
+        <GtmScript />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
         <link rel="shortcut icon" href="https://image.listywave.com/favicon/favicon.png" />
         <link rel="apple-touch-icon" href="https://image.listywave.com/favicon/favicon.png" />
@@ -63,6 +65,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         </CommonProvider>
         <GoogleAnalytics gaId={`${gtag.GA_TRACKING_ID}`} />
       </body>
+      <GtmNoScript />
     </html>
   );
 }

--- a/src/app/list/[listId]/_components/ListDetailInner/CollectButton.tsx
+++ b/src/app/list/[listId]/_components/ListDetailInner/CollectButton.tsx
@@ -58,7 +58,7 @@ const CollectButton = ({ data }: { data: CollectProps }) => {
         </div>
         {isOn && (
           <Modal handleModalClose={handleSetOff} size="large">
-            <LoginModal />
+            <LoginModal id="collectLoginBtn" />
           </Modal>
         )}
       </>

--- a/src/app/list/[listId]/_components/ListDetailOuter/Comments.tsx
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Comments.tsx
@@ -249,7 +249,7 @@ function Comments() {
     <>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="commentLoginBtn" />
         </Modal>
       )}
       <div className={styles.wrapper}>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -36,7 +36,7 @@ export default function LoginPage() {
       </section>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="loginPageBtn" />
         </Modal>
       )}
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,7 +56,7 @@ function LandingPage() {
       </div>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="redirectedLoginBtn" />
         </Modal>
       )}
     </>

--- a/src/app/user/[userId]/_components/FollowButton.tsx
+++ b/src/app/user/[userId]/_components/FollowButton.tsx
@@ -90,7 +90,7 @@ export default function FollowButton({ isFollowed, userId }: FollowButtonProps) 
       </button>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="followLoginBtn" />
         </Modal>
       )}
     </>

--- a/src/components/BottomNav/BottomNav.tsx
+++ b/src/components/BottomNav/BottomNav.tsx
@@ -82,7 +82,7 @@ export default function BottomNav() {
       </nav>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="bottomNavLoginBtn" />
         </Modal>
       )}
     </>

--- a/src/components/exploreComponents/FollowButton.tsx
+++ b/src/components/exploreComponents/FollowButton.tsx
@@ -98,7 +98,7 @@ function FollowButton({ isFollowing, onClick, userId, targetId }: FollowButtonPr
       </button>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="exploreFollowLoginBtn" />
         </Modal>
       )}
     </>

--- a/src/components/exploreComponents/Header.tsx
+++ b/src/components/exploreComponents/Header.tsx
@@ -50,7 +50,7 @@ function Header() {
     <nav className={styles.wrapper}>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="headerLoginBtn" />
         </Modal>
       )}
       <div className={styles.userInfoOuterWrapper}>

--- a/src/components/floatingButton/PlusOptionFloatingButton.tsx
+++ b/src/components/floatingButton/PlusOptionFloatingButton.tsx
@@ -53,7 +53,7 @@ function FloatingMenu() {
       </div>
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="floatingLoginBtn" />
         </Modal>
       )}
     </>

--- a/src/components/login/LoginModal.tsx
+++ b/src/components/login/LoginModal.tsx
@@ -20,7 +20,11 @@ const oauthType = {
   kakao: 'kakao',
 };
 
-export default function LoginModal() {
+interface LoginModalProps {
+  id: string;
+}
+
+export default function LoginModal({ id }: LoginModalProps) {
   const { language } = useLanguage();
   return (
     <section className={styles.container}>
@@ -47,7 +51,7 @@ export default function LoginModal() {
         <Link href={`${baseUrl}/auth/${oauthType.google}`}>
           <GoogleLoginIcon />
         </Link> */}
-        <Link id="btn_login" href={`${process.env.NEXT_PUBLIC_SERVER_DOMAIN}/auth/${oauthType.kakao}`}>
+        <Link id={id} href={`${process.env.NEXT_PUBLIC_SERVER_DOMAIN}/auth/${oauthType.kakao}`}>
           <KakaoLoginIcon />
         </Link>
       </div>

--- a/src/components/login/LoginModal.tsx
+++ b/src/components/login/LoginModal.tsx
@@ -47,7 +47,7 @@ export default function LoginModal() {
         <Link href={`${baseUrl}/auth/${oauthType.google}`}>
           <GoogleLoginIcon />
         </Link> */}
-        <Link href={`${process.env.NEXT_PUBLIC_SERVER_DOMAIN}/auth/${oauthType.kakao}`}>
+        <Link id="btn_login" href={`${process.env.NEXT_PUBLIC_SERVER_DOMAIN}/auth/${oauthType.kakao}`}>
           <KakaoLoginIcon />
         </Link>
       </div>

--- a/src/lib/utils/gtag.tsx
+++ b/src/lib/utils/gtag.tsx
@@ -12,12 +12,13 @@ export const event = ({ action, parameters }: any) => {
   window.gtag('event', action, parameters);
 };
 
+const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_ID;
 //Google Tag Manager
 export const GtmScript = () => {
   return (
     <script
       dangerouslySetInnerHTML={{
-        __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T36W9G3V');`,
+        __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${GTM_CONTAINER_ID}');`,
       }}
     />
   );
@@ -28,7 +29,7 @@ export const GtmNoScript = () => {
   return (
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-T36W9G3V"
+        src={`https://www.googletagmanager.com/ns.html?id=${GTM_CONTAINER_ID}`}
         height="0"
         width="0"
         style={{ display: 'none', visibility: 'hidden' }}

--- a/src/lib/utils/gtag.tsx
+++ b/src/lib/utils/gtag.tsx
@@ -11,3 +11,28 @@ export const pageview = (url: string) => {
 export const event = ({ action, parameters }: any) => {
   window.gtag('event', action, parameters);
 };
+
+//Google Tag Manager
+export const GtmScript = () => {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T36W9G3V');`,
+      }}
+    />
+  );
+};
+
+//Google Tag Manager - noscript
+export const GtmNoScript = () => {
+  return (
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-T36W9G3V"
+        height="0"
+        width="0"
+        style={{ display: 'none', visibility: 'hidden' }}
+      />
+    </noscript>
+  );
+};

--- a/src/lib/utils/gtm.tsx
+++ b/src/lib/utils/gtm.tsx
@@ -1,17 +1,3 @@
-export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID;
-
-// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url: string) => {
-  window.gtag('config', GA_TRACKING_ID, {
-    page_path: url,
-  });
-};
-
-// https://developers.google.com/analytics/devguides/collection/gtagjs/events
-export const event = ({ action, parameters }: any) => {
-  window.gtag('event', action, parameters);
-};
-
 const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_ID;
 //Google Tag Manager
 export const GtmScript = () => {


### PR DESCRIPTION
## 개요
- GTM(Google Tag Manager) 이용을 위한 코드를 삽입했습니다.
- 로그인 버튼 클릭 특정을 위해, 로그인버튼 Link 태그에 id를 삽입했습니다.

<br>

## 작업 사항
### 코드 수정
- [x] layout의 `<head>`태그 내 최상단, `<body>`태그 내 최 상단에 삽입
- [x] LoginModal의 카카오톡 로그인 버튼에 id 삽입
- [x] GA코드 삭제
- [x] 로그인 버튼 페이지에 따라 class 또는 id 달라지도록 설정하기 (로그인  모달 뜨는 경우는 아래 참고)
     - `/intro`: `introLoginBtn`
     - `/`: `headerLoginBtn`, `redirectedLoginBtn`(접근불가 페이지 접속시 리다이렉트 된 경우), `exploreFollowLoginBtn`
     - `/` or `/user` : `floatingLoginBtn`
     - `/search` or `/`:  `bottomNavLoginBtn`
     - `/user` : `followLoginBtn`
     - `/list`: `collectLoginBtn`, `commentLoginBtn`, `DuplicateList`
     - `/login`: `loginPageBtn`

- [ ] 비회원 '이 타이틀로 리스트 생성하기' 버튼 클릭시 로그인 모달 띄우기 + 버튼id추가 (생성페이지 이동 차단) - refactor/duplicateList

### 기타
- [x] GTM에 GA연결
- [x] GTM 컨테이너ID 새로 발급
- [ ] GTM 상황별 버튼 이벤트 추가

<br>

## 참고 사항
- 참고  링크: https://datarian.io/blog/create-gtm-account