### PR TITLE
Fix: 댓글 폼 TextArea로 수정, 댓글/답글 관련 버그 수정

### DIFF
--- a/src/app/list/[listId]/_components/ListDetailOuter/Comment.css.ts
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Comment.css.ts
@@ -65,6 +65,7 @@ export const commentContent = style({
   fontWeight: 500,
   lineHeight: 'normal',
   letterSpacing: '-0.36px',
+  wordBreak: 'break-word',
 });
 
 export const deletedComment = style({

--- a/src/app/list/[listId]/_components/ListDetailOuter/Comment.tsx
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Comment.tsx
@@ -11,7 +11,7 @@ import timeDiff from '@/lib/utils/time-diff';
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { CommentType } from '@/lib/types/commentType';
 import { UserType } from '@/lib/types/userProfileType';
-import { useCommentId } from '@/store/useComment';
+import { useCommentId, useCommentStatus } from '@/store/useComment';
 import { commentLocale } from '@/app/list/[listId]/locale';
 
 import * as styles from './Comment.css';
@@ -25,9 +25,10 @@ import { useLanguage } from '@/store/useLanguage';
  */
 interface CommentProps {
   comment?: CommentType;
-  onUpdate: (userName?: string) => void;
+  setActiveNickname: (userName?: string) => void;
   activeNickname?: string | null;
   handleSetCommentId: (id: number | undefined) => void;
+  handleSetComment: (comment: string) => void;
   listId?: number;
   commentId?: number;
   currentUserInfo?: UserType;
@@ -36,17 +37,18 @@ interface CommentProps {
 
 function Comment({
   comment,
-  onUpdate,
+  setActiveNickname: onUpdate,
   handleSetCommentId,
+  handleSetComment,
   listId,
   commentId,
   currentUserInfo,
-
   handleEdit,
 }: CommentProps) {
   const { language } = useLanguage();
   const queryClient = useQueryClient();
   const { setCommentId } = useCommentId();
+  const { setStatusCreateReply, setStatusEdit } = useCommentStatus();
 
   //현재 작성중인 답글의 원댓글 정보를 업데이트 하는 로직
   const handleActiveNicknameAndIdUpdate = () => {
@@ -55,11 +57,15 @@ function Comment({
     if (!currentUserName && !currentCommentId) {
       return null;
     }
+    handleSetComment('');
+    setStatusCreateReply();
     onUpdate(currentUserName);
     handleSetCommentId(currentCommentId);
   };
 
+  //수정하기 버튼을 누르면 실행되는 함수
   const handleEditButtonClick = (comment: string) => {
+    setStatusEdit();
     handleEdit(comment);
     setCommentId(commentId as number);
   };

--- a/src/app/list/[listId]/_components/ListDetailOuter/CommentForm.tsx
+++ b/src/app/list/[listId]/_components/ListDetailOuter/CommentForm.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent } from 'react';
 
 import { useUser } from '@/store/useUser';
-import { useIsEditing } from '@/store/useComment';
+import { useIsEditing, useCommentStatus } from '@/store/useComment';
 import * as styles from './Comments.css';
 import CancelButton from '/public/icons/cancel_button.svg';
 import { vars } from '@/styles/theme.css';
@@ -31,6 +31,7 @@ function CommentForm({
   handleUpdate,
   handleCancel,
 }: CommentFormProps) {
+  const { status } = useCommentStatus();
   const { language } = useLanguage();
   const { isEditing } = useIsEditing();
 
@@ -40,7 +41,7 @@ function CommentForm({
   return (
     <div className={styles.formWrapperOuter}>
       <div className={`${styles.formWrapperInner} ${!!activeNickname || isEditing ? styles.activeFormWrapper : ''}`}>
-        {activeNickname && (
+        {status === 'createReply' && activeNickname && (
           <div className={styles.activeReplyWrapper}>
             <span className={styles.replyNickname}>
               {language === 'ko'
@@ -57,7 +58,7 @@ function CommentForm({
             />
           </div>
         )}
-        {isEditing && (
+        {status === 'edit' && isEditing && (
           <div className={styles.activeReplyWrapper}>
             <span className={styles.replyNickname}>{commentLocale[language].editing}</span>
             <CancelButton

--- a/src/app/list/[listId]/_components/ListDetailOuter/Comments.css.ts
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Comments.css.ts
@@ -54,7 +54,7 @@ export const formContainer = style({
 export const formInput = style({
   width: '100%',
   height: '20px',
-  maxHeight: '80px',
+  maxHeight: '60px',
 
   flex: '1 0 0',
 

--- a/src/app/list/[listId]/_components/ListDetailOuter/Comments.css.ts
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Comments.css.ts
@@ -52,17 +52,25 @@ export const formContainer = style({
 });
 
 export const formInput = style({
-  width: 'inherit',
-  height: 'auto',
+  width: '100%',
+  height: '20px',
+  maxHeight: '80px',
 
   flex: '1 0 0',
 
+  display: 'block',
+  overflow: 'hidden',
+  resize: 'none',
+  outline: 'none',
+  border: 'none',
   fontSize: '1.6rem',
   wordBreak: 'break-all',
   wordWrap: 'break-word',
   whiteSpace: 'pre-wrap',
-  resize: 'none',
   backgroundColor: vars.color.gray3,
+  '::-webkit-scrollbar': {
+    display: 'none',
+  },
 });
 
 export const replyNickname = style({

--- a/src/app/list/[listId]/_components/ListDetailOuter/Comments.tsx
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Comments.tsx
@@ -181,7 +181,7 @@ function Comments() {
       setIsPending(true);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.getComments, commentId] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.getComments] });
       addCommentId(commentId as number);
       scrollToRef();
     },

--- a/src/app/list/[listId]/_components/ListDetailOuter/Comments.tsx
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Comments.tsx
@@ -203,7 +203,7 @@ function Comments() {
   });
 
   //댓글/답글 폼 submit 함수
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement> | React.KeyboardEvent<HTMLTextAreaElement>) => {
     e.preventDefault();
     if (!comment.trim()) {
       return null;

--- a/src/app/list/[listId]/_components/ListDetailOuter/Comments.tsx
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Comments.tsx
@@ -108,7 +108,7 @@ function Comments() {
   };
 
   //댓글 폼 사용(추후 리액트 훅폼으로 수정해 볼 예정)
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setComment(e.target.value);
   };
 

--- a/src/app/list/[listId]/_components/ListDetailOuter/Replies.tsx
+++ b/src/app/list/[listId]/_components/ListDetailOuter/Replies.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import DeleteModalButton from '@/app/list/[listId]/_components/ListDetailOuter/DeleteModalButton';
 import deleteReply from '@/app/_api/comment/deleteReply';
-import { useCommentIdStore, useReplyId, useCommentId } from '@/store/useComment';
+import { useCommentIdStore, useReplyId, useCommentId, useCommentStatus } from '@/store/useComment';
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import timeDiff from '@/lib/utils/time-diff';
 import { ReplyType } from '@/lib/types/commentType';
@@ -78,6 +78,7 @@ interface ReplyProps {
 function Reply({ reply, listId, currentUserInfo, handleEdit, commentId }: ReplyProps) {
   const { language } = useLanguage();
   const queryClient = useQueryClient();
+  const { setStatusEdit } = useCommentStatus();
   const { setCommentId } = useCommentId();
   const { setReplyId } = useReplyId();
   const deleteReplyMutation = useMutation({
@@ -88,6 +89,7 @@ function Reply({ reply, listId, currentUserInfo, handleEdit, commentId }: ReplyP
   });
 
   const handleEditButtonClick = (content: string) => {
+    setStatusEdit();
     handleEdit(content);
     setCommentId(commentId as number);
     setReplyId(reply?.id);

--- a/src/hooks/useEnterKeyDown.ts
+++ b/src/hooks/useEnterKeyDown.ts
@@ -1,0 +1,17 @@
+interface IProps {
+  handleSubmit: (e: React.FormEvent<HTMLFormElement> | React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  isSubmitting: boolean;
+}
+
+function usePressEnterFetch({ handleSubmit, isSubmitting }: IProps) {
+  const handlePressEnterFetch = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !isSubmitting) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  return { handlePressEnterFetch };
+}
+
+export default usePressEnterFetch;

--- a/src/store/useComment.ts
+++ b/src/store/useComment.ts
@@ -47,3 +47,17 @@ export const useIsEditing = create<UseIsEditingType>((set) => ({
   setIsNotEditing: () => set({ isEditing: false }),
   setToggleEditing: (state) => set({ isEditing: !state }),
 }));
+
+interface useCommentStatusType {
+  status: null | 'edit' | 'createReply';
+  setStatusEdit: () => void;
+  setStatusCreateReply: () => void;
+  resetStatus: () => void;
+}
+
+export const useCommentStatus = create<useCommentStatusType>((set) => ({
+  status: null,
+  setStatusEdit: () => set({ status: 'edit' }),
+  setStatusCreateReply: () => set({ status: 'createReply' }),
+  resetStatus: () => set({ status: null }),
+}));


### PR DESCRIPTION
## 개요

- 개요는 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.
- 해당 PR에 대한 리뷰어와 라벨을 생성해 주세요.

<br>

## 작업 사항

- 댓글 폼을 TextArea로 바꾸었습니다. (바꾸고 나니 엔터키를 누르면 바로 전송이 안됐지만 엔터키를 누르면 폼이 전송되도록 하는 키보드 함수를 추가했습니다.)
- 댓글 수정과 답글 생성이 동시에 가능하지 않도록 수정했습니다.
- 답글 수정 이후 재렌더링이 일어나지 않는 이유를 발견했습니다. (쿼리 무효화 함수 수정)

<br>

## 참고 사항 (optional)
- useResizeTextarea 훅을 사용했습니다. 
- 훅을 사용하여 폼 전송하고 이후 자동으로 크기가 줄어들게 하고 싶었는데, blur/focus 이외에는 폼의 크기를 되돌릴 수 있는 방법을 찾지 못했습니당..(일단 임시로 하드코딩 해두었습니다)

<br>

## 관련 이슈 (optional)
closed: #196 
closed: #208
closed: #209 

<br>

## 스크린샷

댓글 textarea로 수정, 댓글수정/ 답글 달기 동시에 되는 문제 해결

https://github.com/8-Sprinters/ListyWave-front/assets/142777396/69a5d6f0-e1a2-4ff0-8012-09b808b46018

답글 수정 반영 안되는 버그 해결


https://github.com/8-Sprinters/ListyWave-front/assets/142777396/7a20e82b-679a-4cfa-8166-40b2ff286e15



<br>

## 리뷰어에게

- 어떤 부분에 리뷰어가 집중하면 좋을지

<br>
