### PR TITLE
Refactor: 리스트 상세 '이 타이틀로 리스트 생성하기' 비회원 접근 시 로직 수정

### DIFF
--- a/src/app/list/[listId]/_components/ListDetailInner/Footer.tsx
+++ b/src/app/list/[listId]/_components/ListDetailInner/Footer.tsx
@@ -126,7 +126,7 @@ function Footer({ data }: { data: FooterProps }) {
       )}
       {isOn && (
         <Modal handleModalClose={handleSetOff} size="large">
-          <LoginModal />
+          <LoginModal id="duplicateListLoginBtn" />
         </Modal>
       )}
       <div className={styles.container}>

--- a/src/app/list/[listId]/_components/ListDetailInner/Footer.tsx
+++ b/src/app/list/[listId]/_components/ListDetailInner/Footer.tsx
@@ -2,20 +2,25 @@
 
 import { MouseEvent, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
+import Script from 'next/script';
 import * as styles from './Footer.css';
 
 import { useUser } from '@/store/useUser';
+import { useLanguage } from '@/store/useLanguage';
 import { ItemType } from '@/lib/types/listType';
 import { UserProfileType } from '@/lib/types/userProfileType';
+import toasting from '@/lib/utils/toasting';
 import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import ModalPortal from '@/components/modal-portal';
+import { listLocale } from '@/app/list/[listId]/locale';
 import CollectButton from '@/app/list/[listId]/_components/ListDetailInner/CollectButton';
 import getBottomSheetOptionList from '@/app/list/[listId]/_components/ListDetailInner/getBottomSheetOptionList';
 import ShareIcon from '/public/icons/share.svg';
 import EtcIcon from '/public/icons/etc.svg';
 import EyeIcon from '/public/icons/eye.svg';
-import Script from 'next/script';
-import { useLanguage } from '@/store/useLanguage';
+import Modal from '@/components/Modal/Modal';
+import LoginModal from '@/components/login/LoginModal';
+import useBooleanOutput from '@/hooks/useBooleanOutput';
 
 interface BottomSheetOptionsProps {
   key: string;
@@ -49,6 +54,7 @@ function Footer({ data }: { data: FooterProps }) {
   const router = useRouter();
   const path = usePathname();
   const { user: loginUser } = useUser();
+  const { isOn, handleSetOff, handleSetOn } = useBooleanOutput();
   const [isSheetActive, setSheetActive] = useState<boolean>(false);
   const [sheetOptionList, setSheetOptionList] = useState<BottomSheetOptionsProps[]>([]);
   const listUrl = `https://listywave.com${path}`;
@@ -60,9 +66,20 @@ function Footer({ data }: { data: FooterProps }) {
     // console.log('kakaoShareStatus:', window.Kakao.isInitialized());
   }
 
-  const goToCreateList = () => {
-    router.push(`/list/create?title=${data.title}&category=${data.category}`);
-  };
+  let goToCreateList: () => void;
+
+  if (loginUser.id === null) {
+    goToCreateList = () => {
+      toasting({ type: 'default', txt: listLocale[language].loginRequired });
+      setSheetActive(false);
+      handleSetOn();
+    };
+  } else {
+    goToCreateList = () => {
+      toasting({ type: 'default', txt: listLocale[language].moveToCreateListPageMessage });
+      router.push(`/list/create?title=${data.title}&category=${data.category}`);
+    };
+  }
 
   const closeBottomSheet = () => {
     setSheetActive(false);
@@ -106,6 +123,11 @@ function Footer({ data }: { data: FooterProps }) {
         <ModalPortal>
           <BottomSheet onClose={handleOutsideClick} isActive={isSheetActive} optionList={sheetOptionList} />
         </ModalPortal>
+      )}
+      {isOn && (
+        <Modal handleModalClose={handleSetOff} size="large">
+          <LoginModal />
+        </Modal>
       )}
       <div className={styles.container}>
         <div className={styles.collectAndView}>

--- a/src/app/list/[listId]/_components/ListDetailInner/getBottomSheetOptionList.ts
+++ b/src/app/list/[listId]/_components/ListDetailInner/getBottomSheetOptionList.ts
@@ -3,7 +3,6 @@ import { UserProfileType } from '@/lib/types/userProfileType';
 import kakaotalkShare from '@/components/KakaotalkShare/kakaotalkShare';
 import copyUrl from '@/lib/utils/copyUrl';
 import saveImageFromHtml from '@/lib/utils/saveImageFromHtml';
-import toasting from '@/lib/utils/toasting';
 import { listLocale } from '@/app/list/[listId]/locale';
 
 interface OptionDataProps {
@@ -92,7 +91,6 @@ const getBottomSheetOptionList = ({
         key: 'copyAndCreateList',
         title: listLocale[language].createListToThisTitle,
         onClick: () => {
-          toasting({ type: 'default', txt: listLocale[language].moveToCreateListPageMessage });
           goToCreateList();
         },
       },

--- a/src/app/list/[listId]/locale.ts
+++ b/src/app/list/[listId]/locale.ts
@@ -39,6 +39,7 @@ export const replyLocale = {
 export const listLocale: Record<string, { [key: string]: string }> = {
   ko: {
     privateMessage: '비공개 처리된 게시물이에요.',
+    loginRequired: '로그인이 필요합니다.',
     list: '리스트',
     public: '공개',
     private: '비공개',
@@ -70,6 +71,7 @@ export const listLocale: Record<string, { [key: string]: string }> = {
   },
   en: {
     privateMessage: "It's a closed post.",
+    loginRequired: 'Login is required.',
     list: 'List',
     public: 'Public',
     private: 'Private',


### PR DESCRIPTION
## 개요
- 리스트 상세 '이 타이틀로 리스트 생성하기'를 비회원이 접속 할 경우의 로직을  수정했습니다.
**현재:** 클릭 -> 생성페이지 -> userId가 없어 '/'으로 redirect 및 login 모달 열림 (=>탐색 페이지)
**변경:** 클릭 -> userId가 없으면 로그인 모달 열림 (=>여전히 해당 리스트상세 페이지)

<br>

## 작업 사항
- 비회원 '이 타이틀로 리스트 생성하기' 버튼 클릭시 로그인 모달 띄우기
- 해당 로그인 모달의 버튼id추가 (생성페이지 이동 차단)

<br>

## 관련 이슈 (optional) 
#221 

<br>

## 리뷰어에게
- 비회원이 '이 타이틀로 생성하기' 클릭시, 바로 탐색페이지로 리다이렉트 되던 것을 로그인 모달 노출로 변경했습니다!

<br>
