### PR TITLE
Fix: GTM 태그 재삽입

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import type { Metadata, Viewport } from 'next';
 import { ToastContainer } from 'react-toastify';
-import { GtmScript, GtmNoScript } from '@/lib/utils/gtm';
+import { GoogleTagManager } from '@next/third-parties/google';
 
 import BottomNav from '@/components/BottomNav/BottomNav';
 
@@ -47,7 +47,6 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="ko">
       <head>
-        <GtmScript />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
         <link rel="manifest" href="/manifest.json" />
         <link rel="shortcut icon" href="https://image.listywave.com/favicon/favicon.png" />
@@ -55,7 +54,6 @@ export default function Layout({ children }: { children: ReactNode }) {
         <meta name="theme-color" content="#ffffff" />
       </head>
       <body className={styles.body}>
-        <GtmNoScript />
         <CommonProvider>
           <div id="modal-root" />
           <div>
@@ -65,6 +63,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <ToastContainer className={styles.toastContainer} />
         </CommonProvider>
       </body>
+      <GoogleTagManager gtmId="GTM-5XF9QJN8" />
     </html>
   );
 }


### PR DESCRIPTION
## 개요

- GTM 태그 삽입코드가 적용이 안되는지,,, 구글 태그 매니저에서 태그 감지를 못해 다른 방식으로 삽입해보았습니다.

<br>

## 작업 사항
- Next에 `import { GoogleTagManager } from '@next/third-parties/google'` 이런게 있길래, 이걸 사용해보았습니다!
-

## 리뷰어에게

- 이 방식도 안된다면 새로운 방법도 시도해보겠습니다!
