### PR TITLE
Hotfix: 마이페이지 드롭다운 컴포넌트 수정(커스텀 훅 대신 useState로 관리)

### DIFF
--- a/src/app/account/_components/LanguageDropdown.tsx
+++ b/src/app/account/_components/LanguageDropdown.tsx
@@ -1,25 +1,43 @@
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+
 import * as styles from './LanguageDropdown.css';
+
 import { useLanguage } from '@/store/useLanguage';
 import { accountLocale } from '@/app/account/locale';
+import useBooleanOutput from '@/hooks/useBooleanOutput';
 
 export default function LanguageDropdown() {
-  const [isOn, setIsOn] = useState(false);
-  const dropDownRef = useRef(null);
+  const dropDownRef = useRef<HTMLDivElement>(null);
+  const { isOn, handleSetOff, toggle } = useBooleanOutput();
   const { language, setLanguage } = useLanguage();
 
   const handleSelectLanguage = (language: 'ko' | 'en') => {
     setLanguage(language);
-    setIsOn(false);
+    handleSetOff();
   };
 
-  const handleToggle = () => {
-    setIsOn((prev) => !prev);
-  };
+  const handleClickOutside = useCallback(
+    (e: Event) => {
+      if (dropDownRef.current !== null && !dropDownRef.current.contains(e.target as Node)) {
+        handleSetOff();
+      }
+    },
+    [handleSetOff]
+  );
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchend', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.addEventListener('touchend', handleClickOutside);
+    };
+  }, [handleClickOutside]);
 
   return (
-    <div ref={dropDownRef} className={styles.container}>
-      <div className={styles.triggerDiv} onClick={handleToggle}>
+    <div className={styles.container} ref={dropDownRef}>
+      <div className={styles.triggerDiv} onClick={toggle}>
         {language === 'ko' ? accountLocale[language].korean : accountLocale[language].english}
       </div>
       {isOn && (

--- a/src/app/account/_components/LanguageDropdown.tsx
+++ b/src/app/account/_components/LanguageDropdown.tsx
@@ -1,23 +1,25 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import * as styles from './LanguageDropdown.css';
-import useBooleanOutput from '@/hooks/useBooleanOutput';
-import useOnClickOutside from '@/hooks/useOnClickOutside';
 import { useLanguage } from '@/store/useLanguage';
 import { accountLocale } from '@/app/account/locale';
 
 export default function LanguageDropdown() {
-  const { isOn, toggle, handleSetOff } = useBooleanOutput();
-  const { ref } = useOnClickOutside(handleSetOff);
+  const [isOn, setIsOn] = useState(false);
+  const dropDownRef = useRef(null);
   const { language, setLanguage } = useLanguage();
 
   const handleSelectLanguage = (language: 'ko' | 'en') => {
     setLanguage(language);
-    handleSetOff();
+    setIsOn(false);
+  };
+
+  const handleToggle = () => {
+    setIsOn((prev) => !prev);
   };
 
   return (
-    <div ref={ref} className={styles.container}>
-      <div className={styles.triggerDiv} onClick={toggle}>
+    <div ref={dropDownRef} className={styles.container}>
+      <div className={styles.triggerDiv} onClick={handleToggle}>
         {language === 'ko' ? accountLocale[language].korean : accountLocale[language].english}
       </div>
       {isOn && (


### PR DESCRIPTION
## 개요

- 마이페이지 내 각 옵션이 클릭되지 않는 버그를 수정했습니다.
- 언어 변경 드롭다운 컴포넌트(LanguageDropdown)의 로직을 수정했습니다.

<br>

## 작업 사항

- useOnClickOutSide 훅으로 ref를 가져오는 대신 LanguageDropdown 컴포넌트에서 ref를 생성
- useState로 토글 상태 관리

<br>

## 참고 사항 

- 문제 상황: 지난번 모달 외부 클릭 시 클릭이벤트도 함께 발생하는 버그를 e.preventDefault()로 수정하였습니다.
- 문제 원인: LanguageDropdown 컴포넌트에서 사용하는 ref가 useOnClickOutSide에서 받아올 때 ref.current가 있는 상태이므로, 다른 옵션을 선택했을 때, 클릭 이벤트를 막는 로직을 타서 제대로 동작하지 않았습니다. 
- 해결 방법: 모바일에서 터치시 클릭이벤트가 동작하므로 touchend이벤트를 제거하는 방법과 고민했지만, 근본적인 해결방법이 아닌것 같아서 훅을 사용하지 않고 클릭이벤트(터치이벤트)를 처리하는 방법을 선택했습니다.

<br>

## 리뷰어에게

- 브라우저 환경, 모바일 환경에서 모달 테스트를 진행했습니다.
- 서영님 리뷰 부탁드립니다!!🥹 (@seoyoung-min )
- 마이페이지에서 ref를 내려주는 방법을 한번 더 시도해 보겠습니다.🧐

<br>
