### PR TITLE
Fix: 배포환경에서 node_modules에서 .d.ts 찾지 못함 이슈 해결 - .d.ts 파일 경로 변경과 tsconf…

### DIFF
--- a/src/lib/types/react-ios-pwa-prompt/index.d.ts
+++ b/src/lib/types/react-ios-pwa-prompt/index.d.ts
@@ -1,0 +1,20 @@
+declare module 'react-ios-pwa-prompt' {
+  import React from 'react';
+
+  interface PWAPromptProps {
+    timesToShow?: number;
+    promptOnVisit?: number;
+    permanentlyHideOnDismiss?: boolean;
+    copyTitle?: string;
+    copyBody?: string;
+    copyShareButtonLabel?: string;
+    copyAddHomeButtonLabel?: string;
+    copyClosePrompt?: string;
+    delay?: number;
+    debug?: boolean;
+    onClose?: () => void;
+  }
+
+  const PWAPrompt: React.ComponentType<PWAPromptProps>;
+  export default PWAPrompt;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "typeRoots": ["./types ", "./node_modules/@types", "./node_modules/@types/@yaireo"],
+    "typeRoots": ["./types ", "./node_modules/@types", "src/lib/types/react-ios-pwa-prompt"],
     "declaration": true,
     "declarationDir": "./types",
     "target": "es5",


### PR DESCRIPTION

## 개요

- Fix: 버셀 배포환경에서 node_modules에서 .d.ts 찾지 못함 이슈 해결 


<br>

## 작업 사항

- node_modules 폴더는 gitignore됨.
- node_modules 아래에 선언해두었던 외부라이브러리의 타입 선언 파일(.d.ts)이 깃헙에 올라가지 않았음.
- 깃헙 브랜치만을 참고하는 버셀 배포환경에서 라이브러리 타입 선언을 찾을 수 없다는 에러때문에 배포가 막혔음

- node_modules를 git ignore에서 제외시켜 git tracking 시키면 쉽게 해결가능함.
- 하지만, node_modules는 굉장히 큰 폴더이고, 빌드시에 매번 포함될 필요가 없는 폴더인데, 이 라이브러리 타입 선언 파일 하나때문에 gitignore에서 제외시켜 git tracking 시키는것은 득보다 실이 크다고 판단.
- 따라서 필요한 .d.ts 파일 하나만 git tracking이 되는 lib/types 폴더 아래에 위치시키고 tsconfig에 컴파일옵션에 이 위치를 포함시켜서 해결함.


<br>


