### PR TITLE
Hotfix: IOS PWA앱설치 유도 메시지 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const withVanillaExtract = createVanillaExtractPlugin();
 
 const withPWA = require('next-pwa')({
   dest: 'public',
+  disable: process.env.NODE_ENV === 'development',
 });
 
 /** @type {import('next').NextConfig} */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,8 +53,8 @@ function LandingPage() {
           <PWAPrompt
             copyTitle="리스티웨이브 앱 설치하기"
             copyBody="앱으로 더 편하게 리스티웨이브의 모든 기능을 이용해보세요"
-            copyShareButtonLabel="1) 공유하기 아이콘"
-            copyAddHomeButtonLabel="2) 홈화면에 추가"
+            copyShareButtonLabel="1) Chrome 혹은 Safari에서 공유하기 아이콘 누른 후"
+            copyAddHomeButtonLabel="2) 홈화면에 추가 누르면 완료"
             copyClosePrompt="닫기"
             timesToShow={100}
             permanentlyHideOnDismiss={false}


### PR DESCRIPTION
## 개요

- 카카오톡이나 인스타그램으로 링크 접속시 열리는 화면은 브라우저 환경이 아님.
- 브라우저 환경이 아니라서, 공유하기 -> 홈화면 추가하기 옵션이 존재하지 않음.
- 아이폰으로 링크 접속 후 바로 뜨는 IOS 앱설치 유도 팝업에서는 홈화면 추가 아이콘을 클릭하라고 안내하기에 혼란을 유발할 가능성이 있음.
- 따라서 **브라우저 환경 접속 후** 공유 및 홈화면 추가 아이콘 클릭을 유도하는 방향으로 프롬프트 메시지 수정함

수정 전
- "1) 공유하기 아이콘"
- "2) 홈화면에 추가"

수정 후
- "1) Chrome 혹은 Safari에서 공유하기 아이콘 누른 후"
- "2) 홈화면에 추가 누르면 완료"

<br>

## 작업 사항

- IOS PWA prompt 메시지 수정
- localhost에서 pwa 워크박스 관련 개발용 콘솔출력 없앰

