### PR TITLE
Refactor: 토큰을 주고 받는 방식을 Set-cookie로 수정함에 따른 관련 로직 수정

### DIFF
--- a/src/app/auth/redirect/kakao/page.tsx
+++ b/src/app/auth/redirect/kakao/page.tsx
@@ -7,7 +7,6 @@ import { AxiosError } from 'axios';
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { useUser } from '@/store/useUser';
 import { UserOnLoginType } from '@/lib/types/user';
-import { setCookie } from '@/lib/utils/cookie';
 
 import Loading from '@/components/loading/Loading';
 
@@ -34,10 +33,8 @@ export default function KakaoRedirectPage() {
           signal: controller.signal,
         });
 
-        const { id, accessToken, refreshToken } = res.data;
-        updateUser({ id, accessToken: '' }); // TODO id만 저장하기
-        setCookie('accessToken', accessToken, 'AT');
-        setCookie('refreshToken', refreshToken, 'RT');
+        const { id } = res.data;
+        updateUser({ id });
 
         if (res.data.isFirst) {
           router.push('/start-listy');

--- a/src/components/login/LoginModal.tsx
+++ b/src/components/login/LoginModal.tsx
@@ -9,14 +9,7 @@ import KakaoLoginIcon from '/public/icons/kakao_login_narrow.svg';
 import { commonLocale } from '@/components/locale';
 import { useLanguage } from '@/store/useLanguage';
 
-// 다른 소셜 로그인 도입을 위해 주석처리 해둠
-// import NaverLoginIcon from '/public/icons/naver_login.svg';
-// import GoogleLoginIcon from '/public/icons/google_login.svg';
-// import KakaoLoginIcon from '/public/icons/kakao_login.svg';
-
 const oauthType = {
-  naver: 'naver',
-  google: 'google',
   kakao: 'kakao',
 };
 
@@ -45,12 +38,6 @@ export default function LoginModal({ id }: LoginModalProps) {
         </div>
       </div>
       <div className={styles.buttonContainer}>
-        {/* <Link href={`${baseUrl}/auth/${oauthType.naver}`}>
-          <NaverLoginIcon />
-        </Link>
-        <Link href={`${baseUrl}/auth/${oauthType.google}`}>
-          <GoogleLoginIcon />
-        </Link> */}
         <Link id={id} href={`${process.env.NEXT_PUBLIC_SERVER_DOMAIN}/auth/${oauthType.kakao}`}>
           <KakaoLoginIcon />
         </Link>

--- a/src/store/useUser.ts
+++ b/src/store/useUser.ts
@@ -4,18 +4,16 @@ import { UserOnLoginType } from '@/lib/types/user';
 
 interface InitialUserType {
   id: null;
-  accessToken: '';
 }
 
 interface UserStateType {
-  user: InitialUserType | Pick<UserOnLoginType, 'id' | 'accessToken'>;
-  updateUser: (user: Pick<UserOnLoginType, 'id' | 'accessToken'>) => void;
+  user: InitialUserType | Pick<UserOnLoginType, 'id'>;
+  updateUser: (user: Pick<UserOnLoginType, 'id'>) => void;
   logoutUser: () => void;
 }
 
 const initialValue: InitialUserType = {
   id: null,
-  accessToken: '',
 };
 
 // 사용자 정보(id) 및 상태(로그인, 로그아웃)를 저장하는 store


### PR DESCRIPTION
## 개요

- 기존 Response body로 받은 토큰을 Authorization header로 요청 보내는 방식에서 Set-cookie로 주고 받는 방식으로 변경했습니다.
- 리액트 쿠키 라이브러리를 사용하여 저장하는 대신 Set-cookie 헤더를 통해 자동으로 쿠키를 저장 및 요청이 가능하고, 보안 및 refreshToken을 장기적으로 유지시킬 수 있는 이점이 있기 때문에 Set-cookie 방식으로 변경했습니다. (*백엔드 먼저 작업 완료한 상태)

<br>

## 작업 사항

- axiosInstance 쿠키 옵션 설정
- RefreshToken으로 AccessToken 재발급 받는 response.interceptors 로직 수정
- 전역 상태 useUser store에 사용자 id만 저장되도록 수정

<br>

## 참고 사항 (optional)

- ⭐️ 로그인 시 같은 도메인(listywave.com)에서만 쿠키가 저장되는 이슈로, merge 후 수정한 코드 테스트가 필요합니다.
  - (참고) Docker와 Nginx를 설정하여 테스트 진행 예정입니다.
- 👀 테스트 정상 작동 확인 후에, 리액트 쿠키를 사용한 코드의 후속 작업 진행 예정입니다.
  - 로그아웃, 탈퇴 시 쿠키 삭제 로직
  - 라이브러리 삭제

<br>

## 리뷰어에게

- 감사합니다. 파이팅!!🥳

<br>
