### PR TITLE
Feat: 리스트 배경색 확장 및 팔레트 도입, 컬러 hex 원시값이 아닌 컬러코드로 통신

### DIFF
--- a/src/app/collection/[category]/_components/Top3Card.tsx
+++ b/src/app/collection/[category]/_components/Top3Card.tsx
@@ -10,6 +10,7 @@ import Top3CardItem from './Top3CardItem';
 import DefaultProfile from '/public/icons/default_profile.svg';
 import { collectionLocale } from '@/app/collection/locale';
 import { useLanguage } from '@/store/useLanguage';
+import { BACKGROUND_COLOR_READ } from '@/styles/Color';
 
 // TODO: search 아래의 Top3Card와 공통으로 수정하기
 export default function Top3Card({ collectionList }: { collectionList: CollectionType }) {
@@ -26,7 +27,7 @@ export default function Top3Card({ collectionList }: { collectionList: Collectio
       <div
         className={styles.container}
         style={assignInlineVars({
-          [styles.listColor]: `${list.backgroundColor}`,
+          [styles.listColor]: `${BACKGROUND_COLOR_READ[list.backgroundColor as keyof typeof BACKGROUND_COLOR_READ]}`,
           [styles.listBackgroundImage]: `url(${list.representativeImageUrl})`,
         })}
         onClick={handleCardClick}

--- a/src/app/list/[listId]/_components/ListDetailInner/index.tsx
+++ b/src/app/list/[listId]/_components/ListDetailInner/index.tsx
@@ -8,6 +8,7 @@ import { ListDetailType } from '@/lib/types/listType';
 import Header from '@/app/list/[listId]/_components/ListDetailInner/Header';
 import RankList from '@/app/list/[listId]/_components/ListDetailInner/RankList';
 import Footer from '@/app/list/[listId]/_components/ListDetailInner/Footer';
+import { BACKGROUND_COLOR_PALETTE_TYPE, BACKGROUND_COLOR_READ } from '@/styles/Color';
 
 interface OptionsProps {
   value: string;
@@ -47,7 +48,11 @@ function ListDetailInner({ data, listId }: ListDetailInnerProps) {
     <div className={styles.container}>
       <Header handleChangeListType={handleChangeListType} />
       <div className={styles.listAndFooter}>
-        <RankList backgroundColor={data?.backgroundColor} listData={listData} type={listType} />
+        <RankList
+          backgroundColor={BACKGROUND_COLOR_READ[data?.backgroundColor as keyof typeof BACKGROUND_COLOR_READ]}
+          listData={listData}
+          type={listType}
+        />
         <Footer data={footerData} />
       </div>
     </div>

--- a/src/app/list/[listId]/edit/page.tsx
+++ b/src/app/list/[listId]/edit/page.tsx
@@ -45,7 +45,8 @@ export default function EditPage() {
       title: '',
       description: '',
       isPublic: true,
-      backgroundColor: '#ffffff',
+      backgroundPalette: 'PASTEL',
+      backgroundColor: 'PASTEL_PINK',
       items: [],
     },
   });
@@ -123,6 +124,7 @@ export default function EditPage() {
         title: listDetailData.title,
         description: listDetailData.description,
         isPublic: listDetailData.isPublic,
+        backgroundPalette: listDetailData.backgroundPalette,
         backgroundColor: listDetailData.backgroundColor,
         items: listDetailData.items.map(({ id, rank, title, comment, link, imageUrl }) => {
           return {

--- a/src/app/list/create/_components/CreateList.tsx
+++ b/src/app/list/create/_components/CreateList.tsx
@@ -12,6 +12,7 @@ import SimpleInput from './list/SimpleInput';
 import ButtonSelector from './list/ButtonSelector';
 import LabelInput from './list/LabelInput';
 import MemberSelector from './list/MemberSelector';
+import PaletteSelector from './list/PaletteSelector';
 import ColorSelector from './list/ColorSelector';
 import RadioInput from './list/RadioInput';
 
@@ -21,7 +22,7 @@ import getCategories from '@/app/_api/category/getCategories';
 import getFollowingList from '@/app/_api/follow/getFollowingList';
 import { CategoryType } from '@/lib/types/categoriesType';
 import { FollowingListType } from '@/lib/types/followType';
-import { BACKGROUND_COLOR } from '@/styles/Color';
+import { BACKGROUND_COLOR_PALETTE_TYPE } from '@/styles/Color';
 import { listPlaceholder } from '@/lib/constants/placeholder';
 import { listDescriptionRules, listLabelRules, listTitleRules } from '@/lib/constants/formInputValidationRules';
 
@@ -32,6 +33,11 @@ import { listLocale } from '@/app/list/create/locale';
 interface CreateListProps {
   onNextClick: () => void;
   type: 'create' | 'edit';
+}
+
+interface OptionsProps {
+  value: string;
+  label: string;
 }
 
 /**
@@ -54,6 +60,8 @@ function CreateList({ onNextClick, type }: CreateListProps) {
   const collaboIDs = useWatch({ control, name: 'collaboratorIds' });
   const title = useWatch({ control, name: 'title' });
   const category = useWatch({ control, name: 'category' });
+  const palette = useWatch({ control, name: 'backgroundPalette' });
+  const [selectedPalette, setSelectedPalette] = useState<BACKGROUND_COLOR_PALETTE_TYPE>(palette);
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -174,11 +182,19 @@ function CreateList({ onNextClick, type }: CreateListProps) {
 
         {/* 배경 색상 */}
         <Section title={listLocale[language].backgroundcolor} isRequired={true}>
+          <PaletteSelector
+            palette={palette}
+            handleChangePalette={(target: OptionsProps) => {
+              const value: BACKGROUND_COLOR_PALETTE_TYPE = target.value as BACKGROUND_COLOR_PALETTE_TYPE;
+              setSelectedPalette(value);
+            }}
+          />
           <ColorSelector
+            palette={selectedPalette}
             defaultColor={getValues('backgroundColor')}
-            colors={Object.values(BACKGROUND_COLOR)}
             onClick={(color: string) => {
               setValue('backgroundColor', color);
+              setValue('backgroundPalette', palette);
             }}
           />
         </Section>

--- a/src/app/list/create/_components/list/ColorSelector.tsx
+++ b/src/app/list/create/_components/list/ColorSelector.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
+import { BACKGROUND_COLOR_CREATE, BACKGROUND_COLOR_PALETTE_TYPE } from '@/styles/Color';
 import * as styles from './ColorSelector.css';
 
 interface ColorSelectorProps {
+  palette: BACKGROUND_COLOR_PALETTE_TYPE;
   defaultColor: string;
-  colors: string[];
   onClick: (color: string) => void;
 }
 
@@ -12,11 +13,11 @@ interface ColorSelectorProps {
  * 동그란 모양의 컬러팔레트로 구성된
  * 사용자의 클릭으로 색상을 선택할 수 있는 컴포넌트
  *
- * @param defaultColor - 기본 선택되는 색상 (#포함 6자리 hex코드 ("#ffffff"))
- * @param colors - #포함 6자리 hex코드 리스트 (["#ffffff",])
+ * @param palette - 선택된 팔레트
+ * @param defaultColor - 기본 선택되어있는 색상코드
  * @param onClick - 색상 원을 클릭했을때 동작시킬 함수
  */
-function ColorSelector({ defaultColor, colors, onClick }: ColorSelectorProps) {
+function ColorSelector({ palette, defaultColor, onClick }: ColorSelectorProps) {
   const [selectedColor, setSelectedColor] = useState(defaultColor);
 
   useEffect(() => {
@@ -25,14 +26,14 @@ function ColorSelector({ defaultColor, colors, onClick }: ColorSelectorProps) {
 
   return (
     <div className={styles.backgroundContainer}>
-      {colors.map((color) => (
+      {Object.values(BACKGROUND_COLOR_CREATE[palette].colors).map(({ colorID, hex }) => (
         <button
-          key={color}
-          className={`${styles.colorCircle} ${selectedColor.toLocaleLowerCase() === color.toLocaleLowerCase() && styles.selectedColor}`}
-          style={{ backgroundColor: color }}
+          key={colorID}
+          className={`${styles.colorCircle} ${selectedColor.toLocaleUpperCase() === colorID.toLocaleUpperCase() && styles.selectedColor}`}
+          style={{ backgroundColor: hex }}
           onClick={() => {
-            onClick(color);
-            setSelectedColor(color);
+            onClick(colorID);
+            setSelectedColor(colorID);
           }}
         />
       ))}

--- a/src/app/list/create/_components/list/PaletteSelector.css.ts
+++ b/src/app/list/create/_components/list/PaletteSelector.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  width: '100%',
+
+  padding: '0 30px 5px 40px',
+
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+});

--- a/src/app/list/create/_components/list/PaletteSelector.tsx
+++ b/src/app/list/create/_components/list/PaletteSelector.tsx
@@ -1,0 +1,39 @@
+import SelectComponent from '@/components/SelectComponent/SelectComponent';
+import { useLanguage } from '@/store/useLanguage';
+import { BACKGROUND_COLOR_CREATE, BACKGROUND_COLOR_PALETTE_TYPE } from '@/styles/Color';
+import { paletteLocale } from '../../locale';
+import * as styles from './PaletteSelector.css';
+
+interface OptionsProps {
+  value: string;
+  label: string;
+}
+
+interface HeaderProps {
+  palette: BACKGROUND_COLOR_PALETTE_TYPE;
+  handleChangePalette: (target: OptionsProps) => void | undefined;
+}
+
+//TODO : 팔레트 드롭다운 locale 적용 안되는 이슈 해결
+function PaletteSelector({ palette, handleChangePalette }: HeaderProps) {
+  const { language } = useLanguage();
+
+  const dropdownOptions = Object.keys(BACKGROUND_COLOR_CREATE).map((key) => ({
+    value: key,
+    label: paletteLocale[language][key],
+  }));
+
+  return (
+    <div className={styles.container}>
+      <SelectComponent
+        defaultValue={{ value: palette, label: paletteLocale[language][palette] }}
+        name="palette"
+        options={dropdownOptions}
+        isSearchable={false}
+        onChange={handleChangePalette}
+      />
+    </div>
+  );
+}
+
+export default PaletteSelector;

--- a/src/app/list/create/locale.ts
+++ b/src/app/list/create/locale.ts
@@ -73,3 +73,27 @@ export const listLocale = {
     privateMessage: 'Only I can see this list.',
   },
 };
+
+type PaletteLocale = {
+  ko: {
+    [key: string]: string;
+  };
+  en: {
+    [key: string]: string;
+  };
+};
+
+export const paletteLocale: PaletteLocale = {
+  ko: {
+    PASTEL: '파스텔',
+    VIVID: '비비드',
+    GRAY: '그레이',
+    LISTY: '리스티',
+  },
+  en: {
+    PASTEL: 'Pastel',
+    VIVID: 'Vivid',
+    GRAY: 'Gray',
+    LISTY: 'Listy',
+  },
+};

--- a/src/app/list/create/page.tsx
+++ b/src/app/list/create/page.tsx
@@ -34,7 +34,8 @@ export default function CreatePage() {
       title: '',
       description: '',
       isPublic: true,
-      backgroundColor: '#FFFFFF',
+      backgroundPalette: 'PASTEL',
+      backgroundColor: 'PASTEL_PINK',
       items: [
         {
           rank: 0,

--- a/src/app/search/_components/Top3Card.tsx
+++ b/src/app/search/_components/Top3Card.tsx
@@ -10,6 +10,7 @@ import Top3CardItem from './Top3CardItem';
 import DefaultProfile from '/public/icons/default_profile.svg';
 import { searchLocale } from '@/app/search/locale';
 import { useLanguage } from '@/store/useLanguage';
+import { BACKGROUND_COLOR_READ } from '@/styles/Color';
 
 export default function Top3Card({ list }: { list: SearchListType }) {
   const { language } = useLanguage();
@@ -23,7 +24,7 @@ export default function Top3Card({ list }: { list: SearchListType }) {
       <div
         className={styles.container}
         style={assignInlineVars({
-          [styles.listColor]: `${list.backgroundColor}`,
+          [styles.listColor]: `${BACKGROUND_COLOR_READ[list.backgroundColor as keyof typeof BACKGROUND_COLOR_READ]}`,
           [styles.listBackgroundImage]: `url(${list.representImageUrl})`,
         })}
         onClick={handleCardClick}

--- a/src/app/user/[userId]/_components/Card.tsx
+++ b/src/app/user/[userId]/_components/Card.tsx
@@ -5,6 +5,7 @@ import * as styles from './Card.css';
 import useMoveToPage from '@/hooks/useMoveToPage';
 import LockIcon from '/public/icons/lock_alt.svg';
 import { ListType } from '@/lib/types/listType';
+import { BACKGROUND_COLOR_READ } from '@/styles/Color';
 
 interface CardProps {
   list: ListType;
@@ -22,7 +23,7 @@ export default function Card({ list, isOwner }: CardProps) {
       onClick={onClickMoveToPage(`/list/${list.id}`)}
       className={styles.container}
       style={assignInlineVars({
-        [styles.listColor]: `${list.backgroundColor}`,
+        [styles.listColor]: `${BACKGROUND_COLOR_READ[list.backgroundColor as keyof typeof BACKGROUND_COLOR_READ]}`,
       })}
     >
       {isVisibleLockIcon && (

--- a/src/lib/types/listType.ts
+++ b/src/lib/types/listType.ts
@@ -1,4 +1,5 @@
 import { UserProfileType } from './userProfileType';
+import { BACKGROUND_COLOR_PALETTE_TYPE } from '@/styles/Color';
 
 // 아이템 생성 타입
 export interface ItemCreateType {
@@ -17,6 +18,7 @@ export interface ListCreateType {
   title: string;
   description: string;
   isPublic: boolean;
+  backgroundPalette: BACKGROUND_COLOR_PALETTE_TYPE;
   backgroundColor: string;
   items: ItemCreateType[];
 }
@@ -29,6 +31,7 @@ export interface ListEditType {
   title: string;
   description: string;
   isPublic: boolean;
+  backgroundPalette: BACKGROUND_COLOR_PALETTE_TYPE;
   backgroundColor: string;
   items: ItemCreateType[];
 }
@@ -105,6 +108,7 @@ export interface ListDetailType {
   items: ItemType[];
   isCollected: boolean;
   isPublic: boolean;
+  backgroundPalette: BACKGROUND_COLOR_PALETTE_TYPE;
   backgroundColor: string;
   collectCount: number;
   viewCount: number;

--- a/src/styles/Color.ts
+++ b/src/styles/Color.ts
@@ -1,8 +1,71 @@
-export const BACKGROUND_COLOR = {
-  WHITE: '#FFFFFF',
-  YELLOW: '#FFF6A5',
-  ORANGE: '#FFDCB2',
-  GREEN: '#D0FF89',
-  BLUE: '#B7EEFF',
-  PURPLE: '#E6C6FF',
+export type BACKGROUND_COLOR_PALETTE_TYPE = 'PASTEL' | 'VIVID' | 'GRAY' | 'LISTY';
+
+//쓰기용 색상팔레트
+//TODO : 글자색 반전 필요한 배경색
+export const BACKGROUND_COLOR_CREATE = {
+  PASTEL: {
+    colors: {
+      0: { colorID: 'PASTEL_PINK', hex: '#FFE0EA' },
+      1: { colorID: 'PASTEL_ORANGE', hex: '#FFEBCB' },
+      2: { colorID: 'PASTEL_YELLOW', hex: '#FFFFDA' },
+      3: { colorID: 'PASTEL_GREEN', hex: '#D9FFD4' },
+      4: { colorID: 'PASTEL_SKYBLUE', hex: '#E0F8FF' },
+      5: { colorID: 'PASTEL_PURPLE', hex: '#E4E0FF' },
+    },
+  },
+  VIVID: {
+    colors: {
+      0: { colorID: 'VIVID_RED', hex: '#FF8080' },
+      1: { colorID: 'VIVID_ORANGE', hex: '#FCCA8D' },
+      2: { colorID: 'VIVID_YELLOW', hex: '#FFF4AA' },
+      3: { colorID: 'VIVID_GREEN', hex: '#96EDA0' },
+      4: { colorID: 'VIVID_BLUE', hex: '#80AAFF' },
+      5: { colorID: 'VIVID_PURPLE', hex: '#9E6AFF' },
+    },
+  },
+  GRAY: {
+    colors: {
+      0: { colorID: 'GRAY_VERYLIGHT', hex: '#F9F9F9' },
+      1: { colorID: 'GRAY_LIGHT', hex: '#DEDEDE' },
+      2: { colorID: 'GRAY_MEDIUM', hex: '#A4A4A4' },
+      // 3: {colorID: 'GRAY_DARK', hex:'#595959'},
+      // 4: {colorID: 'GRAY_VERYDARK', hex:'#353535'},
+      // 5: {colorID: 'GRAY_BLACK', hex:'#000000'},
+    },
+  },
+  LISTY: {
+    colors: {
+      0: { colorID: 'LISTY_WHITE', hex: '#FFFFFF' },
+      1: { colorID: 'LISTY_YELLOW', hex: '#FFF6A5' },
+      2: { colorID: 'LISTY_ORANGE', hex: '#FFDCB2' },
+      3: { colorID: 'LISTY_GREEN', hex: '#D0FF89' },
+      4: { colorID: 'LISTY_BLUE', hex: '#B7EEFF' },
+      5: { colorID: 'LISTY_PURPLE', hex: '#E6C6FF' },
+    },
+  },
+};
+
+//읽기용 색상팔레트
+export const BACKGROUND_COLOR_READ = {
+  PASTEL_PINK: '#FFE0EA',
+  PASTEL_ORANGE: '#FFEBCB',
+  PASTEL_YELLOW: '#FFFFDA',
+  PASTEL_GREEN: '#D9FFD4',
+  PASTEL_SKYBLUE: '#E0F8FF',
+  PASTEL_PURPLE: '#E4E0FF',
+  VIVID_RED: '#FF8080',
+  VIVID_ORANGE: '#FCCA8D',
+  VIVID_YELLOW: '#FFF4AA',
+  VIVID_GREEN: '#96EDA0',
+  VIVID_BLUE: '#80AAFF',
+  VIVID_PURPLE: '#9E6AFF',
+  GRAY_VERYLIGHT: '#F9F9F9',
+  GRAY_LIGHT: '#DEDEDE',
+  GRAY_MEDIUM: '#A4A4A4',
+  LISTY_WHITE: '#FFFFFF',
+  LISTY_YELLOW: '#FFF6A5',
+  LISTY_ORANGE: '#FFDCB2',
+  LISTY_GREEN: '#D0FF89',
+  LISTY_BLUE: '#B7EEFF',
+  LISTY_PURPLE: '#E6C6FF',
 };


### PR DESCRIPTION
## 개요

- 기존 방식 : 서버측과 컬러 hex 값으로 통신
- 바뀐 방식 : PASTEL_PINK 같은 컬러코드로 서버와 통신
- 악의적인 hex값 수정에 대응할 수 없었던 기존 방식에서 코드이용 방식으로 바꾸어 사용자와 로직을 분리 및 은닉시킴
- 팔레트 도입과 색상 추가 

<br>

## 작업 사항

- 팔레트 도입
- 리스트 배경색 추가
- hex값이 아닌 컬러코드로 통신
- 바뀐 API에 영향 받은 부분들 수정 (검색페이지, 마이리스트, 콜라보리스트, 리스트 상세보기 페이지, 트렌딩 리스트)

<br>

## 스크린캡처
<img width="424" alt="image" src="https://github.com/8-Sprinters/ListyWave-front/assets/70089733/9251ce3e-1db3-4842-871e-56fe290d5887">

