### PR TITLE
ListyWave ver2.4.1 : hotfix - 바뀐 컬러코드로 인해 발생한 온보딩 리스트 생성 랜덤 색상 이슈 처리

### DIFF
--- a/src/app/start-listy/_components/CreateListStep.tsx
+++ b/src/app/start-listy/_components/CreateListStep.tsx
@@ -17,7 +17,7 @@ import RegisterItems from './RegisterItems';
 import SkipOnboardingButton from './SkipButton';
 import Spinners from '@/components/loading/Spinners';
 
-import { BACKGROUND_COLOR } from '@/styles/Color';
+import { BACKGROUND_COLOR_READ } from '@/styles/Color';
 import { useLanguage } from '@/store/useLanguage';
 import { startListyLocale } from '@/app/start-listy/locale';
 
@@ -35,10 +35,6 @@ export default function CreateListStep({ nickname }: CreateListStepProps) {
   });
   const [isLoading, setIsLoading] = useState(false);
 
-  // 리스트 생성 배경색상 렌덤하게 적용
-  const listColors = Object.values(BACKGROUND_COLOR);
-  const randomIndex = Math.floor(Math.random() * listColors.length);
-
   const methods = useForm<ListCreateType>({
     mode: 'onChange',
     defaultValues: {
@@ -48,7 +44,7 @@ export default function CreateListStep({ nickname }: CreateListStepProps) {
       title: '',
       description: '',
       isPublic: false,
-      backgroundColor: listColors[randomIndex],
+      backgroundColor: BACKGROUND_COLOR_READ.LISTY_BLUE,
       items: Array.from({ length: 3 }, (_, index) => ({
         rank: index + 1,
         title: '',


### PR DESCRIPTION
## 개요

- 온보딩 과정에서 리스트 배경색을 사용하는것을 캐치하지 못해
- 리스트 배경색 확장 작업 이후 발생한 에러 해결
- 추가로 온보딩 과정에서 리스트 배경색을 랜덤으로 설정해주던 방식에서 리스트 배경색을 지정(LISTY_BLUE)해주는 방식으로 변경함.

<br>
