### PR TITLE
Refactor: refreshToken 만료시간 재설정

### DIFF
--- a/src/app/auth/redirect/kakao/page.tsx
+++ b/src/app/auth/redirect/kakao/page.tsx
@@ -35,7 +35,7 @@ export default function KakaoRedirectPage() {
         });
 
         const { id, accessToken, refreshToken } = res.data;
-        updateUser({ id, accessToken: '' }); // TODO id만 저장하기
+        updateUser({ id });
         setCookie('accessToken', accessToken, 'AT');
         setCookie('refreshToken', refreshToken, 'RT');
 

--- a/src/components/login/LoginModal.tsx
+++ b/src/components/login/LoginModal.tsx
@@ -9,14 +9,7 @@ import KakaoLoginIcon from '/public/icons/kakao_login_narrow.svg';
 import { commonLocale } from '@/components/locale';
 import { useLanguage } from '@/store/useLanguage';
 
-// 다른 소셜 로그인 도입을 위해 주석처리 해둠
-// import NaverLoginIcon from '/public/icons/naver_login.svg';
-// import GoogleLoginIcon from '/public/icons/google_login.svg';
-// import KakaoLoginIcon from '/public/icons/kakao_login.svg';
-
 const oauthType = {
-  naver: 'naver',
-  google: 'google',
   kakao: 'kakao',
 };
 
@@ -45,12 +38,6 @@ export default function LoginModal({ id }: LoginModalProps) {
         </div>
       </div>
       <div className={styles.buttonContainer}>
-        {/* <Link href={`${baseUrl}/auth/${oauthType.naver}`}>
-          <NaverLoginIcon />
-        </Link>
-        <Link href={`${baseUrl}/auth/${oauthType.google}`}>
-          <GoogleLoginIcon />
-        </Link> */}
         <Link id={id} href={`${process.env.NEXT_PUBLIC_SERVER_DOMAIN}/auth/${oauthType.kakao}`}>
           <KakaoLoginIcon />
         </Link>

--- a/src/lib/axios/axiosInstance.ts
+++ b/src/lib/axios/axiosInstance.ts
@@ -7,7 +7,6 @@ import toastMessage from '../constants/toastMessage';
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_SERVER_DOMAIN,
-  // withCredentials: true, // refreshToken을 고려해서 true로 설정
 });
 
 axiosInstance.interceptors.request.use(
@@ -47,14 +46,8 @@ axiosInstance.interceptors.response.use(
         useUser.getState().logoutUser();
         removeCookie('accessToken');
         removeCookie('refreshToken');
-        // toasting({ type: 'error', txt: toastMessage.ko.userStatusLoggedOut });
 
         isRefreshing = true;
-
-        // 토스트 메세지 후 리다이렉트 시키는게 맞는지 확인
-        // setTimeout(() => {
-        //   location.href = '/';
-        // }, 2000);
       }
 
       if (!isRefreshing) {
@@ -77,13 +70,9 @@ axiosInstance.interceptors.response.use(
         } catch (error) {
           // refreshToken 생성 실패 시,
           useUser.getState().logoutUser();
-          removeCookie('accessToken'); // TODO removeCookieAll
+          removeCookie('accessToken');
           removeCookie('refreshToken');
           toasting({ type: 'error', txt: toastMessage.ko.userStatusLoggedOut });
-
-          // setTimeout(() => {
-          //   location.href = '/';
-          // }, 2000);
         } finally {
           isRefreshing = false;
         }

--- a/src/lib/utils/cookie.ts
+++ b/src/lib/utils/cookie.ts
@@ -6,7 +6,7 @@ export const setCookie = (name: string, value: string, type: 'AT' | 'RT') => {
   return cookies.set(name, value, {
     path: '/',
     secure: true,
-    maxAge: type === 'AT' ? 60 * 30 : 60 * 60 * 24, // 현재 refreshToken 쿠키로 전달 도입 전까지, AT는 만료 시간 30분, RT는 24시간으로 설정
+    maxAge: type === 'AT' ? 60 * 30 : 60 * 60 * 24 * 14, // AT는 만료 시간 30분, RT는 14일로 설정
   });
 };
 

--- a/src/store/useUser.ts
+++ b/src/store/useUser.ts
@@ -4,18 +4,16 @@ import { UserOnLoginType } from '@/lib/types/user';
 
 interface InitialUserType {
   id: null;
-  accessToken: '';
 }
 
 interface UserStateType {
-  user: InitialUserType | Pick<UserOnLoginType, 'id' | 'accessToken'>;
-  updateUser: (user: Pick<UserOnLoginType, 'id' | 'accessToken'>) => void;
+  user: InitialUserType | Pick<UserOnLoginType, 'id'>;
+  updateUser: (user: Pick<UserOnLoginType, 'id'>) => void;
   logoutUser: () => void;
 }
 
 const initialValue: InitialUserType = {
   id: null,
-  accessToken: '',
 };
 
 // 사용자 정보(id) 및 상태(로그인, 로그아웃)를 저장하는 store


### PR DESCRIPTION
## 개요

- 로그인 후 토큰이 저장되는 쿠키의 만료시간을 재설정 했습니다. (24시간에서 14일(2주)로 변경)

<br>

## 작업 사항

- 리프레쉬 토큰 만료시간을 2주로 재설정 
- 전역 상태 useUser store에 사용자 id만 저장되도록 수정

<br>

## 참고 사항 (optional)

- 추후 API 통신 할 때, 토큰을 주고 받는 방식을 Authorization header에서 Set-cookie header로 변경 예정에 따라 현재 리액트 쿠키 사용 관련 로직 변경 예정입니다.

<br>

## 리뷰어에게

- 감사합니다!!✨✨

<br>
