### PR TITLE
Refactor: SEO 개선 작업 진행 (metadata, sitemap, robots.txt)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 import type { Metadata, Viewport } from 'next';
+import { ReferrerEnum } from 'next/dist/lib/metadata/types/metadata-types';
+import { OpenGraphType } from 'next/dist/lib/metadata/types/opengraph-types';
 import { ToastContainer } from 'react-toastify';
 import { GoogleTagManager } from '@next/third-parties/google';
 
@@ -9,6 +11,7 @@ import '@/styles/GlobalStyles.css';
 import * as styles from './layout.css';
 
 import CommonProvider from './_context/CommonProvider';
+import METADATA from '@/lib/constants/metadata';
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -19,27 +22,24 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  //  Template Object
   title: {
-    template: '%s | ListyWave',
-    default: 'ListyWave | 리스티웨이브', // 대체 제목 (required),
+    template: METADATA.title.template,
+    default: METADATA.title.default,
   },
-  description:
-    "나의 취향을 리스트로 기록하고, 공유하고, 발견해요. 리스티웨이브에서 모든 기준은 '나의 취향'이에요. 내 취향 가득한 편안한 공간이 되면 좋겠습니다.",
-  authors: [{ name: '에잇🩷' }],
-  generator: 'Next.js',
-  applicationName: 'ListyWave',
-  referrer: 'origin-when-cross-origin', // Referrer-Policy
-  keywords: ['ListyWave', 'list', '리스티웨이브'],
-  metadataBase: new URL('https://listywave.com'),
+  description: METADATA.description.default,
+  authors: [{ name: METADATA.authors.name, url: METADATA.authors.url }],
+  generator: METADATA.generator,
+  applicationName: METADATA.applicationName,
+  referrer: METADATA.referrer as ReferrerEnum,
+  keywords: METADATA.keywords,
+  metadataBase: new URL(METADATA.url),
   openGraph: {
-    title: 'ListyWave',
-    description:
-      "나의 취향을 리스트로 기록하고, 공유하고, 발견해요. 리스티웨이브에서 모든 기준은 '나의 취향'이에요. 내 취향 가득한 편안한 공간이 되면 좋겠습니다.",
-    url: 'https://listywave.com',
-    type: 'website',
-    siteName: 'ListyWave',
-    locale: 'ko',
+    title: METADATA.title.openGraph,
+    description: METADATA.description.default,
+    url: METADATA.url,
+    type: METADATA.type as OpenGraphType,
+    siteName: METADATA.siteName,
+    locale: METADATA.locale,
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,20 +22,20 @@ export const metadata: Metadata = {
   //  Template Object
   title: {
     template: '%s | ListyWave',
-    default: 'ListyWave', // 대체 제목 (required),
+    default: 'ListyWave | 리스티웨이브', // 대체 제목 (required),
   },
   description:
-    "What’s In Your List? 🌊 나의 취향을 리스트로 기록하고, 공유하고, 발견해요. 리스티웨이브에서 모든 기준은 '나의 취향'이에요. 내 취향 가득한 편안한 공간이 되면 좋겠습니다.",
+    "나의 취향을 리스트로 기록하고, 공유하고, 발견해요. 리스티웨이브에서 모든 기준은 '나의 취향'이에요. 내 취향 가득한 편안한 공간이 되면 좋겠습니다.",
   authors: [{ name: '에잇🩷' }],
   generator: 'Next.js',
   applicationName: 'ListyWave',
   referrer: 'origin-when-cross-origin', // Referrer-Policy
-  keywords: ['ListyWave', 'list', 'SNS'],
+  keywords: ['ListyWave', 'list', '리스티웨이브'],
   metadataBase: new URL('https://listywave.com'),
   openGraph: {
     title: 'ListyWave',
     description:
-      "What’s In Your List? 🌊 나의 취향을 리스트로 기록하고, 공유하고, 발견해요. 리스티웨이브에서 모든 기준은 '나의 취향'이에요. 내 취향 가득한 편안한 공간이 되면 좋겠습니다.",
+      "나의 취향을 리스트로 기록하고, 공유하고, 발견해요. 리스티웨이브에서 모든 기준은 '나의 취향'이에요. 내 취향 가득한 편안한 공간이 되면 좋겠습니다.",
     url: 'https://listywave.com',
     type: 'website',
     siteName: 'ListyWave',

--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -4,6 +4,7 @@ import * as styles from './ListDetail.css';
 import ListInformation from '@/app/list/[listId]/_components/ListDetailOuter/ListInformation';
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { ListDetailType } from '@/lib/types/listType';
+import METADATA from '@/lib/constants/metadata';
 
 interface ListDetailProps {
   params: { listId: number };
@@ -15,7 +16,7 @@ export async function generateMetadata({ params }: ListDetailProps, parent: Reso
   const { title, ownerNickname, collaborators, description, items } = data;
 
   const previousImages = (await parent).openGraph?.images || [];
-  const listType = collaborators.length === 0 ? 'Mylist' : 'CollaboList';
+  const listType = collaborators.length === 0 ? 'Mylist' : 'Collabo-list';
 
   return {
     title: {
@@ -26,8 +27,7 @@ export async function generateMetadata({ params }: ListDetailProps, parent: Reso
     openGraph: {
       title: `${title} By.${ownerNickname}`,
       description: `${description || `${ownerNickname}님의 취향을 기록한 리스트입니다.`}`,
-      url: `https://listywave.com/list/${listId}`,
-      type: 'website',
+      url: `${METADATA.url}/list/${listId}`,
       images: [`${items[0].imageUrl}`, ...previousImages],
     },
   };

--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -1,6 +1,37 @@
+import { Metadata, ResolvingMetadata } from 'next';
 import * as styles from './ListDetail.css';
 
 import ListInformation from '@/app/list/[listId]/_components/ListDetailOuter/ListInformation';
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { ListDetailType } from '@/lib/types/listType';
+
+interface ListDetailProps {
+  params: { listId: number };
+}
+
+export async function generateMetadata({ params }: ListDetailProps, parent: ResolvingMetadata): Promise<Metadata> {
+  const listId = params.listId;
+  const { data } = await axiosInstance.get<ListDetailType>(`/lists/${listId}`);
+  const { title, ownerNickname, collaborators, description, items } = data;
+
+  const previousImages = (await parent).openGraph?.images || [];
+  const listType = collaborators.length === 0 ? 'Mylist' : 'CollaboList';
+
+  return {
+    title: {
+      absolute: `${ownerNickname}'s ${listType} - ${data.title}`,
+    },
+    description: `${description}`,
+    authors: [{ name: `${ownerNickname}` }],
+    openGraph: {
+      title: `${title} By.${ownerNickname}`,
+      description: `${description || `${ownerNickname}님의 취향을 기록한 리스트입니다.`}`,
+      url: `https://listywave.com/list/${listId}`,
+      type: 'website',
+      images: [`${items[0].imageUrl}`, ...previousImages],
+    },
+  };
+}
 
 export default function ListDetailPage() {
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import DOMAIN_URL from '@/lib/constants/domain';
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${DOMAIN_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,17 @@
 import type { MetadataRoute } from 'next';
 import DOMAIN_URL from '@/lib/constants/domain';
+import getTrendingLists from './_api/explore/getTrendingLists';
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const result = await getTrendingLists();
+
+  const trendingLists: MetadataRoute.Sitemap = result.map((list) => ({
+    url: `${DOMAIN_URL}/list/${list.id}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly',
+    priority: 0.6,
+  }));
+
   return [
     {
       url: DOMAIN_URL,
@@ -21,5 +31,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.8,
     },
+    ...trendingLists,
   ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+import DOMAIN_URL from '@/lib/constants/domain';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: DOMAIN_URL,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${DOMAIN_URL}/intro`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+    {
+      url: `${DOMAIN_URL}/search`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+  ];
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,12 @@
 import type { MetadataRoute } from 'next';
 import DOMAIN_URL from '@/lib/constants/domain';
-import getTrendingLists from './_api/explore/getTrendingLists';
+// import getTrendingLists from './_api/explore/getTrendingLists';
+import { TrendingListType } from '@/lib/types/exploreType';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const result = await getTrendingLists();
+  const result: TrendingListType[] = await fetch(`${process.env.NEXT_PUBLIC_SERVER_DOMAIN}/lists/explore`).then((res) =>
+    res.json()
+  );
 
   const trendingLists: MetadataRoute.Sitemap = result.map((list) => ({
     url: `${DOMAIN_URL}/list/${list.id}`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,20 +1,7 @@
 import type { MetadataRoute } from 'next';
 import DOMAIN_URL from '@/lib/constants/domain';
-// import getTrendingLists from './_api/explore/getTrendingLists';
-import { TrendingListType } from '@/lib/types/exploreType';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const result: TrendingListType[] = await fetch(`${process.env.NEXT_PUBLIC_SERVER_DOMAIN}/lists/explore`).then((res) =>
-    res.json()
-  );
-
-  const trendingLists: MetadataRoute.Sitemap = result.map((list) => ({
-    url: `${DOMAIN_URL}/list/${list.id}`,
-    lastModified: new Date(),
-    changeFrequency: 'weekly',
-    priority: 0.6,
-  }));
-
   return [
     {
       url: DOMAIN_URL,
@@ -34,6 +21,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'weekly',
       priority: 0.8,
     },
-    ...trendingLists,
   ];
 }

--- a/src/app/user/[userId]/collabolist/page.tsx
+++ b/src/app/user/[userId]/collabolist/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import { Metadata, ResolvingMetadata } from 'next';
 
 import Profile from '../_components/Profile';
 import Content from '../_components/Content';
@@ -6,16 +6,30 @@ import FloatingContainer from '@/components/floatingButton/FloatingContainer';
 import PlusOptionFloatingButton from '@/components/floatingButton/PlusOptionFloatingButton';
 import ArrowUpFloatingButton from '@/components/floatingButton/ArrowUpFloatingButton';
 
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { UserType } from '@/lib/types/userProfileType';
+
 interface CollaboListPageProps {
-  params: {
-    userId: number;
-  };
+  params: { userId: number };
 }
 
-export const metadata: Metadata = {
-  title: 'Collabo List',
-  description: '콜라보레이터와 함께 기록한 리스트 입니다.',
-};
+export async function generateMetadata({ params }: CollaboListPageProps, parent: ResolvingMetadata): Promise<Metadata> {
+  const userId = params.userId;
+  const { data } = await axiosInstance.get<UserType>(`/users/${userId}`);
+
+  const previousImages = (await parent).openGraph?.images || [];
+
+  return {
+    title: {
+      absolute: `${data.nickname}'s CollaboList`,
+    },
+    description: `${data.nickname}님의 콜라보레이터와 함께 기록한 리스트 입니다.`,
+    openGraph: {
+      description: `${data.description ? data.description : `${data.nickname}님의 콜라보레이터와 함께 기록한 리스트 입니다.`}`,
+      images: [`${data.profileImageUrl}`, ...previousImages],
+    },
+  };
+}
 
 export default function CollaboListPage({ params }: CollaboListPageProps) {
   return (

--- a/src/app/user/[userId]/collabolist/page.tsx
+++ b/src/app/user/[userId]/collabolist/page.tsx
@@ -8,6 +8,7 @@ import ArrowUpFloatingButton from '@/components/floatingButton/ArrowUpFloatingBu
 
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { UserType } from '@/lib/types/userProfileType';
+import METADATA from '@/lib/constants/metadata';
 
 interface CollaboListPageProps {
   params: { userId: number };
@@ -21,11 +22,13 @@ export async function generateMetadata({ params }: CollaboListPageProps, parent:
 
   return {
     title: {
-      absolute: `${data.nickname}'s CollaboList`,
+      absolute: `${data.nickname}'s Collabo-list`,
     },
-    description: `${data.nickname}님의 콜라보레이터와 함께 기록한 리스트 입니다.`,
+    authors: [{ name: `${data.nickname}` }],
+    description: METADATA.description.collabolist,
     openGraph: {
-      description: `${data.description ? data.description : `${data.nickname}님의 콜라보레이터와 함께 기록한 리스트 입니다.`}`,
+      description: `${data.description || METADATA.description.collabolist}`,
+      url: `${METADATA.url}/user/${userId}/collabolist`,
       images: [`${data.profileImageUrl}`, ...previousImages],
     },
   };

--- a/src/app/user/[userId]/mylist/page.tsx
+++ b/src/app/user/[userId]/mylist/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import { Metadata, ResolvingMetadata } from 'next';
 
 import Profile from '../_components/Profile';
 import Content from '../_components/Content';
@@ -6,16 +6,30 @@ import FloatingContainer from '@/components/floatingButton/FloatingContainer';
 import PlusOptionFloatingButton from '@/components/floatingButton/PlusOptionFloatingButton';
 import ArrowUpFloatingButton from '@/components/floatingButton/ArrowUpFloatingButton';
 
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { UserType } from '@/lib/types/userProfileType';
+
 interface MyListPageProps {
-  params: {
-    userId: number;
-  };
+  params: { userId: number };
 }
 
-export const metadata: Metadata = {
-  title: 'My List',
-  description: '나의 취향을 기록한 나만의 리스트 입니다.',
-};
+export async function generateMetadata({ params }: MyListPageProps, parent: ResolvingMetadata): Promise<Metadata> {
+  const userId = params.userId;
+  const { data } = await axiosInstance.get<UserType>(`/users/${userId}`);
+
+  const previousImages = (await parent).openGraph?.images || [];
+
+  return {
+    title: {
+      absolute: `${data.nickname}'s Mylist`,
+    },
+    description: `${data.nickname}님의 취향을 기록한 리스트입니다.`,
+    openGraph: {
+      description: `${data.description ? data.description : `${data.nickname}님의 취향을 기록한 리스트입니다.`}`,
+      images: [`${data.profileImageUrl}`, ...previousImages],
+    },
+  };
+}
 
 export default function MyListPage({ params }: MyListPageProps) {
   return (

--- a/src/app/user/[userId]/mylist/page.tsx
+++ b/src/app/user/[userId]/mylist/page.tsx
@@ -8,6 +8,7 @@ import ArrowUpFloatingButton from '@/components/floatingButton/ArrowUpFloatingBu
 
 import axiosInstance from '@/lib/axios/axiosInstance';
 import { UserType } from '@/lib/types/userProfileType';
+import METADATA from '@/lib/constants/metadata';
 
 interface MyListPageProps {
   params: { userId: number };
@@ -23,9 +24,11 @@ export async function generateMetadata({ params }: MyListPageProps, parent: Reso
     title: {
       absolute: `${data.nickname}'s Mylist`,
     },
-    description: `${data.nickname}님의 취향을 기록한 리스트입니다.`,
+    authors: [{ name: `${data.nickname}` }],
+    description: METADATA.description.mylist,
     openGraph: {
-      description: `${data.description ? data.description : `${data.nickname}님의 취향을 기록한 리스트입니다.`}`,
+      description: `${data.description || METADATA.description.mylist}`,
+      url: `${METADATA.url}/user/${userId}/mylist`,
       images: [`${data.profileImageUrl}`, ...previousImages],
     },
   };

--- a/src/lib/constants/domain.ts
+++ b/src/lib/constants/domain.ts
@@ -1,0 +1,3 @@
+const DOMAIN_URL = 'https://listywave.com';
+
+export default DOMAIN_URL;

--- a/src/lib/constants/metadata.ts
+++ b/src/lib/constants/metadata.ts
@@ -1,3 +1,5 @@
+import DOMAIN_URL from './domain';
+
 const METADATA = {
   title: {
     template: '%s | ListyWave', // Template Object
@@ -18,7 +20,7 @@ const METADATA = {
   applicationName: 'ListyWave',
   referrer: 'origin-when-cross-origin', // Referrer-Policy
   keywords: ['ListyWave', 'list', '리스티웨이브'],
-  url: 'https://listywave.com',
+  url: DOMAIN_URL,
   type: 'website',
   siteName: 'ListyWave',
   locale: 'ko',

--- a/src/lib/constants/metadata.ts
+++ b/src/lib/constants/metadata.ts
@@ -1,0 +1,27 @@
+const METADATA = {
+  title: {
+    template: '%s | ListyWave', // Template Object
+    default: 'ListyWave | 리스티웨이브',
+    openGraph: 'ListyWave',
+  },
+  description: {
+    default:
+      "나의 취향을 리스트로 기록하고, 공유하고, 발견해요. 리스티웨이브에서 모든 기준은 '나의 취향'이에요. 내 취향 가득한 편안한 공간이 되면 좋겠습니다.",
+    mylist: '나의 취향을 기록한 리스트 입니다.',
+    collabolist: '콜라보레이터와 함께 기록한 콜라보 리스트 입니다.',
+  },
+  authors: {
+    name: '에잇🩷',
+    url: 'https://github.com/8-Sprinters',
+  },
+  generator: 'Next.js',
+  applicationName: 'ListyWave',
+  referrer: 'origin-when-cross-origin', // Referrer-Policy
+  keywords: ['ListyWave', 'list', '리스티웨이브'],
+  url: 'https://listywave.com',
+  type: 'website',
+  siteName: 'ListyWave',
+  locale: 'ko',
+};
+
+export default METADATA;


### PR DESCRIPTION
## 개요

- 구글 검색엔진 상위 노출을 위한 seo 개선 작업을 진행했습니다.

<br>

## 작업 사항

- 기존 layout 컴포넌트 metadata 수정 (한글 리스티웨이브 추가)
- 마이리스트, 콜라보리스트, 리스트 상세페이지에 dynamic metadata 설정
  - 사용자별, 리스트별로 메타데이터가 설정되도록 반영
- sitemap.ts 설정 (메인, 인트로, 검색페이지, 트렌딩에 해당하는 상세페이지까지 총 13개의 sitemap 추가)
  -  사이트맵이란 사이트에 있는 페이지, 콘텐츠의 각 관계에 관한 정보를 제공하는 파일로, 검색엔진은 이 파일을 읽고 사이트를 더 효율적으로 크롤링한다고 합니다.
- robots.ts 파일 추가

<br>

## 스크린샷

- sitemap 일부 스크린 캡쳐 (sitemap.xml)
<img width="506" alt="image" src="https://github.com/8-Sprinters/ListyWave-front/assets/124856726/534cb62e-6cfb-488f-b358-36c77b97acf6">

<br>

## 리뷰어에게

- 해당 pr 머지후에 결과를 살펴보고, 추가로 개선할 부분이 있는지 파악할 예정입니다. 감사합니다. ✨✨

<br>
