### PR TITLE
Feat: 개인정보 처리방침 페이지 연결 추가

### DIFF
--- a/src/app/intro/_components/Footer.tsx
+++ b/src/app/intro/_components/Footer.tsx
@@ -39,7 +39,12 @@ function Footer() {
             </div>
           </div>
           <div className={styles.policyWrapper}>
-            <p>{introLocale[language].privacy}</p>
+            <Link
+              className={styles.policyWrapper}
+              href={'https://cypress-tv-724.notion.site/2118cc63884e4365b753cac553f3f7ed?pvs=4'}
+            >
+              {introLocale[language].privacy}
+            </Link>
             <p>에잇(Eight)</p>
             <p>Makers : 에잇(Eight, listywave8@gmail.com)</p>
             <p>Copyright ©Listywave - All rights reserved</p>

--- a/src/app/intro/locale.ts
+++ b/src/app/intro/locale.ts
@@ -138,7 +138,7 @@ export const introLocale = {
   en: {
     start: 'Getting started',
     tour: 'Take a tour',
-    privacy: 'Privacy Statement',
+    privacy: 'Privacy',
     exampleTitles: {
       line1: {
         title1: 'My top 10 favorite celebrities',


### PR DESCRIPTION
## 개요
- footer에  개인정보 처리방침 노션 링크를 걸었습니다.

<br>

## 작업 사항
- 개인정보 처리방침 작성
- footer '개인정보 처리방침'에 링크 연결

<br>

## 참고 사항 (optional)

- 2024.04 개정된 개인정보 처리방침 가이드 따라 작성했습니다.

<br>

## 관련 이슈 (optional)
#216 

<br>

## 스크린샷
<img width="616" alt="Screenshot 2024-06-03 at 21 47 50" src="https://github.com/8-Sprinters/ListyWave-front/assets/144652458/993e4a11-37b3-4a4d-ae46-e32a0f7292c7">

<br>

## 리뷰어에게

- 노션링크 한 번씩 읽어봐주시면 감사하겠습니다! 
개인정보처리방침: https://cypress-tv-724.notion.site/2118cc63884e4365b753cac553f3f7ed?pvs=4

<br>
