### PR TITLE
Hotfix: 트렌딩리스트 에러 해결

### DIFF
--- a/src/components/exploreComponents/TrendingLists.css.ts
+++ b/src/components/exploreComponents/TrendingLists.css.ts
@@ -47,7 +47,7 @@ export const listWrapper = style({
   },
 });
 
-export const test = style({
+export const sliderItem = style({
   height: 'auto',
 });
 

--- a/src/components/exploreComponents/TrendingLists.tsx
+++ b/src/components/exploreComponents/TrendingLists.tsx
@@ -67,7 +67,7 @@ function TrendingList() {
       </div>
       <div className={styles.listWrapper}>
         <div className={styles.slide}>
-          {trendingLists && (
+          {trendingLists && trendingLists.length > 0 && (
             <Swiper
               slidesPerView={'auto'}
               grabCursor={true}
@@ -82,36 +82,27 @@ function TrendingList() {
               className="mySwiper"
               style={swiperStyle}
             >
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[0]}>
-                <TrendingListItem item={trendingLists[0]} index={0} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[1]}>
-                <TrendingListItem item={trendingLists[1]} index={1} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[2]}>
-                <TrendingListItem item={trendingLists[2]} index={2} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[3]}>
-                <TrendingListItem item={trendingLists[3]} index={3} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[0]}>
-                <TrendingListItem item={trendingLists[4]} index={4} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[1]}>
-                <TrendingListItem item={trendingLists[5]} index={5} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[2]}>
-                <TrendingListItem item={trendingLists[6]} index={6} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[3]}>
-                <TrendingListItem item={trendingLists[7]} index={7} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[0]}>
-                <TrendingListItem item={trendingLists[8]} index={8} />
-              </SwiperSlide>
-              <SwiperSlide className={styles.test} style={swiperSliderStyle[1]}>
-                <TrendingListItem item={trendingLists[9]} index={9} />
-              </SwiperSlide>
+              {trendingLists.map((item, index) => (
+                <SwiperSlide
+                  key={index}
+                  className={styles.sliderItem}
+                  style={swiperSliderStyle[index % swiperSliderStyle.length]}
+                >
+                  <TrendingListItem item={item} index={index} />
+                </SwiperSlide>
+              ))}
+
+              {/* 슬라이드 개수가 10개 미만일 경우 추가 슬라이드를 생성 */}
+              {trendingLists.length < 10 &&
+                Array.from({ length: 10 - trendingLists.length }).map((_, index) => (
+                  <SwiperSlide
+                    key={`extra-${index}`}
+                    className={styles.sliderItem}
+                    style={swiperSliderStyle[(trendingLists.length + index) % swiperSliderStyle.length]}
+                  >
+                    <TrendingListItem item={trendingLists[index % trendingLists.length]} index={index} />
+                  </SwiperSlide>
+                ))}
             </Swiper>
           )}
         </div>


### PR DESCRIPTION
## 개요

- 개요는 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.
- 해당 PR에 대한 리뷰어와 라벨을 생성해 주세요.

<br>

## 작업 사항

- 트렌딩 리스트가 10개 이하일 때의 예외 처리를 해주었습니다.
- 하드코딩된 탐색 페이지 코드를 최적화 하였습니다.

<br>

## 스크린샷
![image](https://github.com/user-attachments/assets/a83c5968-a7dc-4e5e-83ff-df982e8040b7)


<br>

## 리뷰어에게

- 어떤 부분에 리뷰어가 집중하면 좋을지
- Swiper 라이브러리의 경우, loop 옵션이 켜져 있어도 슬라이드 개수가 적으면 순환이 제대로 되지 않는 경우가 있다고 합니다. 따라서 추가로 슬라이드를 생성해주었습니다. 

<br>
