### PR TITLE
Feat: 어드민 게시물 조회 페이지 UI 및 관련 기능 구현

### DIFF
--- a/src/app/_api/notice/deleteNotice.ts
+++ b/src/app/_api/notice/deleteNotice.ts
@@ -1,0 +1,7 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+
+const deleteNotice = async (noticeId: number) => {
+  await axiosInstance.delete(`/admin/notices/${noticeId}`);
+};
+
+export default deleteNotice;

--- a/src/app/_api/notice/getAdminNotices.ts
+++ b/src/app/_api/notice/getAdminNotices.ts
@@ -1,0 +1,10 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { AdminNoticeType } from '@/lib/types/noticeType';
+
+const getAdminNotices = async () => {
+  const result = await axiosInstance.get<AdminNoticeType[]>('/admin/notices');
+
+  return result.data;
+};
+
+export default getAdminNotices;

--- a/src/app/_api/notice/getNoticeDetail.ts
+++ b/src/app/_api/notice/getNoticeDetail.ts
@@ -1,0 +1,10 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { NoticeDetailType } from '@/lib/types/noticeType';
+
+const getNoticeDetail = async (noticeId: number) => {
+  const result = await axiosInstance.get<NoticeDetailType>(`/notices/${noticeId}`);
+
+  return result.data;
+};
+
+export default getNoticeDetail;

--- a/src/app/_api/notice/sendNoticeAlarm.ts
+++ b/src/app/_api/notice/sendNoticeAlarm.ts
@@ -1,0 +1,7 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+
+const sendNoticeAlarm = async (noticeId: number) => {
+  await axiosInstance.post(`/admin/notices/${noticeId}/alarm`);
+};
+
+export default sendNoticeAlarm;

--- a/src/app/_api/notice/updateNoticePublic.ts
+++ b/src/app/_api/notice/updateNoticePublic.ts
@@ -1,0 +1,7 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+
+const updateNoticePublic = async (noticeId: number) => {
+  await axiosInstance.patch(`/admin/notices/${noticeId}`);
+};
+
+export default updateNoticePublic;

--- a/src/app/admin/layout.css.ts
+++ b/src/app/admin/layout.css.ts
@@ -1,0 +1,40 @@
+import { style } from '@vanilla-extract/css';
+import { Header, BodyRegular } from '@/styles/font.css';
+import { vars } from '@/styles/theme.css';
+
+export const container = style({
+  height: '100vh',
+  display: 'flex',
+});
+
+export const nav = style({
+  padding: '1.5rem',
+
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '3rem',
+
+  borderRight: '2px solid',
+  borderRightColor: vars.color.bluegray6,
+});
+
+export const title = style([
+  Header,
+  {
+    color: vars.color.bluegray8,
+  },
+]);
+
+export const menu = style([
+  BodyRegular,
+  {
+    width: 200,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2rem',
+  },
+]);
+
+export const main = style({
+  flexGrow: 1,
+});

--- a/src/app/admin/layout.css.ts
+++ b/src/app/admin/layout.css.ts
@@ -3,7 +3,7 @@ import { Header, BodyRegular } from '@/styles/font.css';
 import { vars } from '@/styles/theme.css';
 
 export const container = style({
-  height: '100vh',
+  minHeight: '100vh',
   display: 'flex',
 });
 

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+import * as styles from './layout.css';
+import Link from 'next/link';
+
+interface AdminNoticeLayoutProps {
+  children: ReactNode;
+}
+
+export default function AdminNoticeLayout({ children }: AdminNoticeLayoutProps) {
+  return (
+    <section className={styles.container}>
+      <nav className={styles.nav}>
+        <h1 className={styles.title}>🤍 리스티웨이브 관리</h1>
+        <ul className={styles.menu}>
+          <Link href="/admin/topics">요청 주제</Link>
+          <Link href="/admin/notice">게시물</Link>
+        </ul>
+      </nav>
+      <main className={styles.main}>{children}</main>
+    </section>
+  );
+}

--- a/src/app/admin/notice/_components/NoticeItem.css.ts
+++ b/src/app/admin/notice/_components/NoticeItem.css.ts
@@ -1,0 +1,55 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+import { Label } from '@/styles/font.css';
+
+export const bodyRow = style([
+  Label,
+  {
+    padding: '1rem 0.5rem',
+    marginBottom: '1rem',
+    borderBottom: `1px solid ${vars.color.bluegray6}`,
+
+    display: 'grid',
+    gridTemplateColumns: 'repeat(8, 1fr)',
+    alignItems: 'center',
+
+    textAlign: 'center',
+  },
+]);
+
+export const rowItem = style({
+  gridColumn: 'span 2',
+
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+});
+
+export const rowText = style({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const buttons = style({
+  display: 'flex',
+  justifyContent: 'center',
+  gap: '0.5rem',
+});
+
+export const button = style({
+  padding: '0.5rem 1rem',
+  borderRadius: '4px',
+  backgroundColor: vars.color.blue,
+  color: vars.color.white,
+
+  ':hover': {
+    opacity: 0.7,
+  },
+});
+
+export const modal = style({
+  width: '100%',
+  height: '100vh',
+  overflow: 'scroll',
+});

--- a/src/app/admin/notice/_components/NoticeItem.css.ts
+++ b/src/app/admin/notice/_components/NoticeItem.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 import { Label } from '@/styles/font.css';
 
@@ -37,7 +37,7 @@ export const buttons = style({
   gap: '0.5rem',
 });
 
-export const button = style({
+const button = style({
   padding: '0.5rem 1rem',
   borderRadius: '4px',
   backgroundColor: vars.color.blue,
@@ -46,6 +46,17 @@ export const button = style({
   ':hover': {
     opacity: 0.7,
   },
+});
+
+export const variantsButton = styleVariants({
+  default: [button],
+  disabled: [
+    button,
+    {
+      opacity: 0.7,
+      cursor: 'default',
+    },
+  ],
 });
 
 export const modal = style({

--- a/src/app/admin/notice/_components/NoticeItem.tsx
+++ b/src/app/admin/notice/_components/NoticeItem.tsx
@@ -22,7 +22,6 @@ function NoticeDetailModal({ noticeId }: NoticeDetailModalProps) {
   const { data: notices } = useQuery<NoticeDetailType>({
     queryKey: [QUERY_KEYS.getNoticeDetail],
     queryFn: () => getNoticeDetail(noticeId),
-    staleTime: 1000 * 60 * 30,
     enabled: !!noticeId,
   });
 
@@ -83,9 +82,9 @@ function NoticeItem({ notice }: NoticeItemProps) {
           </button>
         </td>
         <td>
-          <select onChange={handleTogglePublic}>
-            <option>{notice.isExposed ? '공개' : '비공개'}</option>
-            <option>{notice.isExposed ? '비공개' : '공개'}</option>
+          <select onChange={handleTogglePublic} value={notice.isExposed ? '공개' : '비공개'}>
+            <option>공개</option>
+            <option>비공개</option>
           </select>
         </td>
       </tr>

--- a/src/app/admin/notice/_components/NoticeItem.tsx
+++ b/src/app/admin/notice/_components/NoticeItem.tsx
@@ -33,13 +33,13 @@ interface NoticeItemProps {
 }
 
 function NoticeItem({ notice }: NoticeItemProps) {
-  const { deletNoticeMutation, sendNoticeAlarmMutation, updateNoticePublicMutation } = useNotice();
+  const { deleteNoticeMutation, sendNoticeAlarmMutation, updateNoticePublicMutation } = useNotice();
   const { isOn, handleSetOn, handleSetOff } = useBooleanOutput();
 
   const { id, title, description, didSendAlarm, isExposed, category, createdDate } = notice;
 
   const handleDeleteNotice = () => {
-    deletNoticeMutation.mutate(id);
+    deleteNoticeMutation.mutate(id);
   };
 
   const handleSendAlarm = () => {

--- a/src/app/admin/notice/_components/NoticeItem.tsx
+++ b/src/app/admin/notice/_components/NoticeItem.tsx
@@ -1,0 +1,104 @@
+import { useQuery } from '@tanstack/react-query';
+
+import * as styles from './NoticeItem.css';
+
+import useNotice from '@/hooks/queries/useNotice';
+import useBooleanOutput from '@/hooks/useBooleanOutput';
+
+import Modal from '@/components/Modal/Modal';
+import NoticeDetailInfo from '@/components/NoticeDetail/NoticeDetailInfo';
+
+import { AdminNoticeType, NoticeDetailType } from '@/lib/types/noticeType';
+import formatDate from '@/lib/utils/dateFormat';
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+
+import getNoticeDetail from '@/app/_api/notice/getNoticeDetail';
+
+interface NoticeDetailModalProps {
+  noticeId: number;
+}
+
+function NoticeDetailModal({ noticeId }: NoticeDetailModalProps) {
+  const { data: notices } = useQuery<NoticeDetailType>({
+    queryKey: [QUERY_KEYS.getNoticeDetail],
+    queryFn: () => getNoticeDetail(noticeId),
+    staleTime: 1000 * 60 * 30,
+    enabled: !!noticeId,
+  });
+
+  return <>{notices && <NoticeDetailInfo noticeData={notices} />}</>;
+}
+
+interface NoticeItemProps {
+  notice: AdminNoticeType;
+}
+
+function NoticeItem({ notice }: NoticeItemProps) {
+  const { deletNoticeMutation, sendNoticeAlarmMutation, updateNoticePublicMutation } = useNotice();
+  const { isOn, handleSetOn, handleSetOff } = useBooleanOutput();
+
+  const handleDeleteNotice = () => {
+    deletNoticeMutation.mutate(notice.id);
+  };
+
+  const handleSendAlarm = () => {
+    if (!notice.isExposed) {
+      alert('공개 게시물만 알림을 보낼 수 있어요.');
+      return;
+    }
+    if (notice.didSendAlarm) {
+      alert('이미 알림을 보낸 게시물입니다.');
+      return;
+    }
+    sendNoticeAlarmMutation.mutate(notice.id);
+  };
+
+  const handleTogglePublic = () => {
+    updateNoticePublicMutation.mutate(notice.id);
+  };
+
+  return (
+    <>
+      <tr className={styles.bodyRow}>
+        <td>{formatDate(notice.createdDate)}</td>
+        <td>{notice.category}</td>
+        <td className={styles.rowItem}>
+          <span className={styles.rowText}>{notice.title}</span>
+          <span className={styles.rowText}>{notice.description}</span>
+        </td>
+        <td className={styles.buttons}>
+          <button className={styles.button}>수정</button>
+          <button className={styles.button} onClick={handleDeleteNotice}>
+            삭제
+          </button>
+        </td>
+        <td>
+          <button className={styles.button} onClick={handleSetOn}>
+            미리보기
+          </button>
+        </td>
+        <td>
+          <button className={styles.button} onClick={handleSendAlarm} disabled={notice.didSendAlarm}>
+            알림보내기
+          </button>
+        </td>
+        <td>
+          <select onChange={handleTogglePublic}>
+            <option>{notice.isExposed ? '공개' : '비공개'}</option>
+            <option>{notice.isExposed ? '비공개' : '공개'}</option>
+          </select>
+        </td>
+      </tr>
+
+      {isOn && (
+        <Modal size="large" handleModalClose={handleSetOff}>
+          <section className={styles.modal}>
+            <NoticeDetailModal noticeId={notice.id} />
+          </section>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+export default NoticeItem;

--- a/src/app/admin/notice/_components/NoticeItem.tsx
+++ b/src/app/admin/notice/_components/NoticeItem.tsx
@@ -36,53 +36,61 @@ function NoticeItem({ notice }: NoticeItemProps) {
   const { deletNoticeMutation, sendNoticeAlarmMutation, updateNoticePublicMutation } = useNotice();
   const { isOn, handleSetOn, handleSetOff } = useBooleanOutput();
 
+  const { id, title, description, didSendAlarm, isExposed, category, createdDate } = notice;
+
   const handleDeleteNotice = () => {
-    deletNoticeMutation.mutate(notice.id);
+    deletNoticeMutation.mutate(id);
   };
 
   const handleSendAlarm = () => {
-    if (!notice.isExposed) {
+    if (!isExposed) {
       alert('공개 게시물만 알림을 보낼 수 있어요.');
       return;
     }
-    if (notice.didSendAlarm) {
+    if (didSendAlarm) {
       alert('이미 알림을 보낸 게시물입니다.');
       return;
     }
-    sendNoticeAlarmMutation.mutate(notice.id);
+    sendNoticeAlarmMutation.mutate(id, {
+      onSuccess: () => alert('알림을 보냈어요.'),
+    });
   };
 
   const handleTogglePublic = () => {
-    updateNoticePublicMutation.mutate(notice.id);
+    updateNoticePublicMutation.mutate(id);
   };
 
   return (
     <>
       <tr className={styles.bodyRow}>
-        <td>{formatDate(notice.createdDate)}</td>
-        <td>{notice.category}</td>
+        <td>{formatDate(createdDate)}</td>
+        <td>{category}</td>
         <td className={styles.rowItem}>
-          <span className={styles.rowText}>{notice.title}</span>
-          <span className={styles.rowText}>{notice.description}</span>
+          <span className={styles.rowText}>{title}</span>
+          <span className={styles.rowText}>{description}</span>
         </td>
         <td className={styles.buttons}>
-          <button className={styles.button}>수정</button>
-          <button className={styles.button} onClick={handleDeleteNotice}>
+          <button className={styles.variantsButton.default}>수정</button>
+          <button className={styles.variantsButton.default} onClick={handleDeleteNotice}>
             삭제
           </button>
         </td>
         <td>
-          <button className={styles.button} onClick={handleSetOn}>
+          <button className={styles.variantsButton.default} onClick={handleSetOn}>
             미리보기
           </button>
         </td>
         <td>
-          <button className={styles.button} onClick={handleSendAlarm} disabled={notice.didSendAlarm}>
-            알림보내기
+          <button
+            className={didSendAlarm ? styles.variantsButton.disabled : styles.variantsButton.default}
+            onClick={handleSendAlarm}
+            disabled={didSendAlarm}
+          >
+            {`알림 ${didSendAlarm ? '완료' : '보내기'}`}
           </button>
         </td>
         <td>
-          <select onChange={handleTogglePublic} value={notice.isExposed ? '공개' : '비공개'}>
+          <select onChange={handleTogglePublic} value={isExposed ? '공개' : '비공개'}>
             <option>공개</option>
             <option>비공개</option>
           </select>
@@ -92,7 +100,7 @@ function NoticeItem({ notice }: NoticeItemProps) {
       {isOn && (
         <Modal size="large" handleModalClose={handleSetOff}>
           <section className={styles.modal}>
-            <NoticeDetailModal noticeId={notice.id} />
+            <NoticeDetailModal noticeId={id} />
           </section>
         </Modal>
       )}

--- a/src/app/admin/notice/page.css.ts
+++ b/src/app/admin/notice/page.css.ts
@@ -55,11 +55,21 @@ export const rowItem = style({
   gap: '0.5rem',
 });
 
+export const rowText = style({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
 export const button = style({
   padding: '0.5rem 1rem',
   borderRadius: '4px',
   backgroundColor: vars.color.blue,
   color: vars.color.white,
+
+  ':hover': {
+    opacity: 0.7,
+  },
 });
 
 export const editButtons = style({

--- a/src/app/admin/notice/page.css.ts
+++ b/src/app/admin/notice/page.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
-import { BodyRegular, Label } from '@/styles/font.css';
+import { BodyRegular } from '@/styles/font.css';
 
 export const page = style({
   padding: '1.5rem',
@@ -32,48 +32,10 @@ export const headRow = style([
   },
 ]);
 
-export const bodyRow = style([
-  Label,
-  {
-    padding: '1rem 0.5rem',
-    marginBottom: '1rem',
-    borderBottom: `1px solid ${vars.color.bluegray6}`,
-
-    display: 'grid',
-    gridTemplateColumns: 'repeat(8, 1fr)',
-    alignItems: 'center',
-
-    textAlign: 'center',
-  },
-]);
-
 export const rowItem = style({
   gridColumn: 'span 2',
 
   display: 'flex',
   flexDirection: 'column',
   gap: '0.5rem',
-});
-
-export const rowText = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-});
-
-export const buttons = style({
-  display: 'flex',
-  justifyContent: 'center',
-  gap: '0.5rem',
-});
-
-export const button = style({
-  padding: '0.5rem 1rem',
-  borderRadius: '4px',
-  backgroundColor: vars.color.blue,
-  color: vars.color.white,
-
-  ':hover': {
-    opacity: 0.7,
-  },
 });

--- a/src/app/admin/notice/page.css.ts
+++ b/src/app/admin/notice/page.css.ts
@@ -61,6 +61,12 @@ export const rowText = style({
   whiteSpace: 'nowrap',
 });
 
+export const buttons = style({
+  display: 'flex',
+  justifyContent: 'center',
+  gap: '0.5rem',
+});
+
 export const button = style({
   padding: '0.5rem 1rem',
   borderRadius: '4px',
@@ -70,10 +76,4 @@ export const button = style({
   ':hover': {
     opacity: 0.7,
   },
-});
-
-export const editButtons = style({
-  display: 'flex',
-  justifyContent: 'center',
-  gap: '0.5rem',
 });

--- a/src/app/admin/notice/page.css.ts
+++ b/src/app/admin/notice/page.css.ts
@@ -1,0 +1,69 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+import { BodyRegular, Label } from '@/styles/font.css';
+
+export const page = style({
+  padding: '1.5rem',
+  height: '100%',
+});
+
+export const table = style({
+  maxWidth: '850px',
+  padding: '1rem',
+
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+
+  backgroundColor: vars.color.white,
+  borderRadius: '8px',
+});
+
+export const headRow = style([
+  BodyRegular,
+  {
+    padding: '1rem 0.5rem',
+
+    display: 'grid',
+    gridTemplateColumns: 'repeat(8, 1fr)',
+    alignItems: 'center',
+
+    textAlign: 'center',
+  },
+]);
+
+export const bodyRow = style([
+  Label,
+  {
+    padding: '1rem 0.5rem',
+    marginBottom: '1rem',
+    borderBottom: `1px solid ${vars.color.bluegray6}`,
+
+    display: 'grid',
+    gridTemplateColumns: 'repeat(8, 1fr)',
+    alignItems: 'center',
+
+    textAlign: 'center',
+  },
+]);
+
+export const rowItem = style({
+  gridColumn: 'span 2',
+
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+});
+
+export const button = style({
+  padding: '0.5rem 1rem',
+  borderRadius: '4px',
+  backgroundColor: vars.color.blue,
+  color: vars.color.white,
+});
+
+export const editButtons = style({
+  display: 'flex',
+  justifyContent: 'center',
+  gap: '0.5rem',
+});

--- a/src/app/admin/notice/page.tsx
+++ b/src/app/admin/notice/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import * as styles from './page.css';
 
 import getAdminNotices from '@/app/_api/notice/getAdminNotices';
+import deleteNotice from '@/app/_api/notice/deleteNotice';
+
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { AdminNoticeType } from '@/lib/types/noticeType';
 import formatDate from '@/lib/utils/dateFormat';
@@ -16,17 +18,32 @@ interface NoticeItemProps {
 }
 
 function NoticeItem({ notice }: NoticeItemProps) {
+  const queryClient = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteNotice,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.getAdminAllNotice] });
+    },
+  });
+
+  const handleDeleteNotice = () => {
+    deleteMutation.mutate(notice.id);
+  };
+
   return (
     <tr className={styles.bodyRow}>
       <td>{formatDate(notice.createdDate)}</td>
       <td>{notice.category}</td>
       <td className={styles.rowItem}>
-        <span> {notice.title}</span>
-        <span>{notice.description}</span>
+        <span className={styles.rowText}>{notice.title}</span>
+        <span className={styles.rowText}>{notice.description}</span>
       </td>
       <td className={styles.editButtons}>
         <button className={styles.button}>수정</button>
-        <button className={styles.button}>삭제</button>
+        <button className={styles.button} onClick={handleDeleteNotice}>
+          삭제
+        </button>
       </td>
       <td>
         <button className={styles.button}>미리보기</button>
@@ -48,6 +65,7 @@ export default function AdminNoticesPage() {
   const { data: notices } = useQuery<AdminNoticeType[]>({
     queryKey: [QUERY_KEYS.getAdminAllNotice],
     queryFn: getAdminNotices,
+    staleTime: 1000 * 60 * 30,
   });
 
   return (

--- a/src/app/admin/notice/page.tsx
+++ b/src/app/admin/notice/page.tsx
@@ -2,9 +2,47 @@
 
 import { useQuery } from '@tanstack/react-query';
 
+import * as styles from './page.css';
+
 import getAdminNotices from '@/app/_api/notice/getAdminNotices';
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { AdminNoticeType } from '@/lib/types/noticeType';
+import formatDate from '@/lib/utils/dateFormat';
+
+const TABLE_ROW = ['일시', '카테고리', '제목&소개', '편집', '미리보기', '알림', '공개'];
+
+interface NoticeItemProps {
+  notice: AdminNoticeType;
+}
+
+function NoticeItem({ notice }: NoticeItemProps) {
+  return (
+    <tr className={styles.bodyRow}>
+      <td>{formatDate(notice.createdDate)}</td>
+      <td>{notice.category}</td>
+      <td className={styles.rowItem}>
+        <span> {notice.title}</span>
+        <span>{notice.description}</span>
+      </td>
+      <td className={styles.editButtons}>
+        <button className={styles.button}>수정</button>
+        <button className={styles.button}>삭제</button>
+      </td>
+      <td>
+        <button className={styles.button}>미리보기</button>
+      </td>
+      <td>
+        <button className={styles.button}>알림보내기</button>
+      </td>
+      <td>
+        <select>
+          <option>{notice.isExposed ? '공개' : '비공개'}</option>
+          <option>{notice.isExposed ? '비공개' : '공개'}</option>
+        </select>
+      </td>
+    </tr>
+  );
+}
 
 export default function AdminNoticesPage() {
   const { data: notices } = useQuery<AdminNoticeType[]>({
@@ -12,7 +50,20 @@ export default function AdminNoticesPage() {
     queryFn: getAdminNotices,
   });
 
-  console.log(notices); // 삭제
-
-  return <div>공지</div>;
+  return (
+    <section className={styles.page}>
+      <table className={styles.table}>
+        <thead>
+          <tr className={styles.headRow}>
+            {TABLE_ROW.map((item, index) => (
+              <th key={index} className={item === '제목&소개' ? styles.rowItem : ''}>
+                {item}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{notices?.map((notice) => <NoticeItem key={notice.id} notice={notice} />)}</tbody>
+      </table>
+    </section>
+  );
 }

--- a/src/app/admin/notice/page.tsx
+++ b/src/app/admin/notice/page.tsx
@@ -8,70 +8,9 @@ import getAdminNotices from '@/app/_api/notice/getAdminNotices';
 
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { AdminNoticeType } from '@/lib/types/noticeType';
-import formatDate from '@/lib/utils/dateFormat';
-
-import useNotice from '@/hooks/queries/useNotice';
+import NoticeItem from './_components/NoticeItem';
 
 const TABLE_ROW = ['일시', '카테고리', '제목&소개', '편집', '미리보기', '알림', '공개'];
-
-interface NoticeItemProps {
-  notice: AdminNoticeType;
-}
-
-function NoticeItem({ notice }: NoticeItemProps) {
-  const { deletNoticeMutation, sendNoticeAlarmMutation, updateNoticePublicMutation } = useNotice();
-
-  const handleDeleteNotice = () => {
-    deletNoticeMutation.mutate(notice.id);
-  };
-
-  const handleSendAlarm = () => {
-    if (!notice.isExposed) {
-      alert('공개 게시물만 알림을 보낼 수 있어요.');
-      return;
-    }
-    if (notice.didSendAlarm) {
-      alert('이미 알림을 보낸 게시물입니다.');
-      return;
-    }
-    sendNoticeAlarmMutation.mutate(notice.id);
-  };
-
-  const handleTogglePublic = () => {
-    updateNoticePublicMutation.mutate(notice.id);
-  };
-
-  return (
-    <tr className={styles.bodyRow}>
-      <td>{formatDate(notice.createdDate)}</td>
-      <td>{notice.category}</td>
-      <td className={styles.rowItem}>
-        <span className={styles.rowText}>{notice.title}</span>
-        <span className={styles.rowText}>{notice.description}</span>
-      </td>
-      <td className={styles.buttons}>
-        <button className={styles.button}>수정</button>
-        <button className={styles.button} onClick={handleDeleteNotice}>
-          삭제
-        </button>
-      </td>
-      <td>
-        <button className={styles.button}>미리보기</button>
-      </td>
-      <td>
-        <button className={styles.button} onClick={handleSendAlarm} disabled={notice.didSendAlarm}>
-          알림보내기
-        </button>
-      </td>
-      <td>
-        <select onChange={handleTogglePublic}>
-          <option>{notice.isExposed ? '공개' : '비공개'}</option>
-          <option>{notice.isExposed ? '비공개' : '공개'}</option>
-        </select>
-      </td>
-    </tr>
-  );
-}
 
 export default function AdminNoticesPage() {
   const { data: notices } = useQuery<AdminNoticeType[]>({

--- a/src/app/admin/notice/page.tsx
+++ b/src/app/admin/notice/page.tsx
@@ -1,17 +1,16 @@
 'use client';
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import * as styles from './page.css';
 
 import getAdminNotices from '@/app/_api/notice/getAdminNotices';
-import deleteNotice from '@/app/_api/notice/deleteNotice';
-import sendNoticeAlarm from '@/app/_api/notice/sendNoticeAlarm';
-import updateNoticePublic from '@/app/_api/notice/updateNoticePublic';
 
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
 import { AdminNoticeType } from '@/lib/types/noticeType';
 import formatDate from '@/lib/utils/dateFormat';
+
+import useNotice from '@/hooks/queries/useNotice';
 
 const TABLE_ROW = ['일시', '카테고리', '제목&소개', '편집', '미리보기', '알림', '공개'];
 
@@ -20,31 +19,10 @@ interface NoticeItemProps {
 }
 
 function NoticeItem({ notice }: NoticeItemProps) {
-  const queryClient = useQueryClient();
-
-  const deleteMutation = useMutation({
-    mutationFn: deleteNotice,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.getAdminAllNotice] });
-    },
-  });
-
-  const sendAlarmMutation = useMutation({
-    mutationFn: sendNoticeAlarm,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.getAdminAllNotice] });
-    },
-  });
-
-  const updatePublicMutation = useMutation({
-    mutationFn: updateNoticePublic,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.getAdminAllNotice] });
-    },
-  });
+  const { deletNoticeMutation, sendNoticeAlarmMutation, updateNoticePublicMutation } = useNotice();
 
   const handleDeleteNotice = () => {
-    deleteMutation.mutate(notice.id);
+    deletNoticeMutation.mutate(notice.id);
   };
 
   const handleSendAlarm = () => {
@@ -56,11 +34,11 @@ function NoticeItem({ notice }: NoticeItemProps) {
       alert('이미 알림을 보낸 게시물입니다.');
       return;
     }
-    sendAlarmMutation.mutate(notice.id);
+    sendNoticeAlarmMutation.mutate(notice.id);
   };
 
   const handleTogglePublic = () => {
-    updatePublicMutation.mutate(notice.id);
+    updateNoticePublicMutation.mutate(notice.id);
   };
 
   return (

--- a/src/app/admin/notice/page.tsx
+++ b/src/app/admin/notice/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import getAdminNotices from '@/app/_api/notice/getAdminNotices';
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+import { AdminNoticeType } from '@/lib/types/noticeType';
+
+export default function AdminNoticesPage() {
+  const { data: notices } = useQuery<AdminNoticeType[]>({
+    queryKey: [QUERY_KEYS.getAdminAllNotice],
+    queryFn: getAdminNotices,
+  });
+
+  console.log(notices); // 삭제
+
+  return <div>공지</div>;
+}

--- a/src/app/notices/[noticeId]/NoticeDetail.tsx
+++ b/src/app/notices/[noticeId]/NoticeDetail.tsx
@@ -21,7 +21,7 @@ function NoticeDetailComponent() {
       </section>
       <article className={styles.articleWrapper}>
         <ul>
-          {data.content?.map((item: NoticeContentType, idx) => (
+          {data.contents?.map((item: NoticeContentType, idx) => (
             <li key={idx.toString()}>
               <NoticeContent item={item} />
             </li>

--- a/src/app/notices/mockdata.ts
+++ b/src/app/notices/mockdata.ts
@@ -64,7 +64,7 @@ export const NOTICE_DETAIL_MOCKDATA: NoticeDetailType = {
   category: '소식',
   title: '서비스 점검 안내',
   description: '서비스 점검이 10월 20일에 진행될 예정입니다.',
-  content: [
+  contents: [
     {
       type: 'subtitle',
       description: '점검 일정',

--- a/src/components/Modal/Modal.css.ts
+++ b/src/components/Modal/Modal.css.ts
@@ -45,6 +45,7 @@ export const sizeVariants = styleVariants<SizeVariantsType>({
     container,
     {
       minWidth: '327px',
+      maxWidth: '420px',
       width: '100%',
       margin: '0px 24px',
       padding: '6rem 2.5rem',

--- a/src/components/NoticeDetail/NoticeDetailContents.css.ts
+++ b/src/components/NoticeDetail/NoticeDetailContents.css.ts
@@ -1,0 +1,57 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/styles/theme.css';
+import { BodyRegular, Subtitle, Label } from '@/styles/font.css';
+
+export const subtitle = style([
+  Subtitle,
+  {
+    color: vars.color.black,
+  },
+]);
+
+export const imgaeBox = style({
+  position: 'relative',
+  height: '400px',
+});
+
+export const image = style({
+  objectFit: 'cover',
+});
+
+export const button = style([
+  BodyRegular,
+  {
+    padding: '16px 14px',
+    width: '100%',
+
+    backgroundColor: vars.color.white,
+    color: vars.color.blue,
+    fontWeight: '700',
+
+    border: `1px solid ${vars.color.blue}`,
+    borderRadius: '18px',
+  },
+]);
+
+export const line = style({
+  width: '100%',
+  height: '2px',
+  margin: '1rem 0',
+
+  backgroundColor: vars.color.lightblue,
+});
+
+export const notice = style([
+  Label,
+  {
+    width: '100%',
+    minHeight: '120px',
+
+    color: vars.color.bluegray8,
+
+    border: 'none',
+    outline: 'none',
+    resize: 'none',
+  },
+]);

--- a/src/components/NoticeDetail/NoticeDetailContents.tsx
+++ b/src/components/NoticeDetail/NoticeDetailContents.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import MDEditor from '@uiw/react-md-editor';
+
+import * as styles from './NoticeDetailContents.css';
+
+import { NoticeContentType } from '@/lib/types/noticeType';
+
+function BodyContent({ description }: Pick<NoticeContentType, 'description'>) {
+  return <MDEditor.Markdown source={description} />;
+}
+
+function SubTitleContent({ description }: Pick<NoticeContentType, 'description'>) {
+  return <h4 className={styles.subtitle}>{description}</h4>;
+}
+
+function ImageContent({ imageUrl }: Pick<NoticeContentType, 'imageUrl'>) {
+  return (
+    <div className={styles.imgaeBox}>
+      <Image src={imageUrl as string} fill className={styles.image} alt="이미지" />
+    </div>
+  );
+}
+
+function ButtonContent({ buttonLink, buttonName }: Pick<NoticeContentType, 'buttonName' | 'buttonLink'>) {
+  return (
+    <Link href={buttonLink as string} target="_blank">
+      <button className={styles.button}>{buttonName}</button>
+    </Link>
+  );
+}
+
+function LineContent() {
+  return <div className={styles.line}></div>;
+}
+
+function NoteContent({ description }: Pick<NoticeContentType, 'description'>) {
+  return <textarea value={description} readOnly className={styles.notice} />;
+}
+
+interface NoticeDetailContentsProps {
+  contents: NoticeContentType;
+}
+
+function NoticeDetailContents({ contents }: NoticeDetailContentsProps) {
+  const { type, description, buttonLink, buttonName, imageUrl } = contents;
+
+  return (
+    <>
+      {type === 'subtitle' && <SubTitleContent description={description} />}
+      {type === 'body' && <BodyContent description={description} />}
+      {type === 'image' && <ImageContent imageUrl={imageUrl} />}
+      {type === 'button' && <ButtonContent buttonLink={buttonLink} buttonName={buttonName} />}
+      {type === 'line' && <LineContent />}
+      {type === 'note' && <NoteContent description={description} />}
+    </>
+  );
+}
+
+export default NoticeDetailContents;

--- a/src/components/NoticeDetail/NoticeDetailInfo.css.ts
+++ b/src/components/NoticeDetail/NoticeDetailInfo.css.ts
@@ -1,0 +1,56 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/styles/theme.css';
+import { Label } from '@/styles/font.css';
+
+export const info = style({
+  padding: '25px 16px 40px',
+
+  display: 'flex',
+  flexDirection: 'column',
+
+  backgroundColor: vars.color.blue,
+});
+
+export const category = style([
+  Label,
+  {
+    width: 'fit-content',
+    padding: '6px 12px',
+    textAlign: 'center',
+
+    backgroundColor: vars.color.white,
+    borderRadius: '16px',
+
+    color: vars.color.bluegray8,
+  },
+]);
+
+export const title = style({
+  marginTop: '14px',
+  marginBottom: '11px',
+
+  color: vars.color.white,
+  fontSize: '2rem',
+  fontWeight: '600',
+});
+
+export const description = style({
+  marginBottom: '4px',
+
+  color: vars.color.white,
+  fontSize: '1.4rem',
+});
+
+export const created = style({
+  color: vars.color.bggray,
+  fontSize: '1rem',
+});
+
+export const contents = style({
+  paddingTop: '2rem',
+
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+});

--- a/src/components/NoticeDetail/NoticeDetailInfo.tsx
+++ b/src/components/NoticeDetail/NoticeDetailInfo.tsx
@@ -1,0 +1,29 @@
+import * as styles from './NoticeDetailInfo.css';
+
+import { NoticeDetailType } from '@/lib/types/noticeType';
+import formatDate from '@/lib/utils/dateFormat';
+import NoticeDetailContents from './NoticeDetailContents';
+
+interface NoticeDetailInfoProps {
+  noticeData: NoticeDetailType;
+}
+
+export default function NoticeDetailInfo({ noticeData }: NoticeDetailInfoProps) {
+  const { category, title, description, contents, createdDate } = noticeData;
+
+  return (
+    <>
+      <header className={styles.info}>
+        <span className={styles.category}>{category}</span>
+        <h3 className={styles.title}>{title}</h3>
+        <p className={styles.description}>{description}</p>
+        <span className={styles.created}>{formatDate(createdDate)}</span>
+      </header>
+      <main className={styles.contents}>
+        {contents.map((item, index) => (
+          <NoticeDetailContents key={index} contents={item} />
+        ))}
+      </main>
+    </>
+  );
+}

--- a/src/hooks/queries/useNotice.ts
+++ b/src/hooks/queries/useNotice.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+import { useMutation, UseMutationOptions, UseMutationResult, useQueryClient } from '@tanstack/react-query';
 
 import deleteNotice from '@/app/_api/notice/deleteNotice';
 import sendNoticeAlarm from '@/app/_api/notice/sendNoticeAlarm';
@@ -23,8 +23,16 @@ const useNoticeMutation = <TData = unknown, TError = unknown, TVariables = unkno
   });
 };
 
+// useNoticeMutation이 반환하는 타입은 UseMutationResult<TData, TError, TVariables, unknown> 타입으로,
+// useNotice 훅이 반환하는 각 함수의 반환값(void), 에러, 변수 타입(number), context 타입을 정의해주었다.
+type UseNoticeReturnType = {
+  deletNoticeMutation: UseMutationResult<void, unknown, number, unknown>;
+  sendNoticeAlarmMutation: UseMutationResult<void, unknown, number, unknown>;
+  updateNoticePublicMutation: UseMutationResult<void, unknown, number, unknown>;
+};
+
 // React-query의 useMutation을 wrapping해주는 Notice 관련 custom hook
-const useNotice = () => {
+const useNotice = (): UseNoticeReturnType => {
   const deletNoticeMutation = useNoticeMutation(deleteNotice);
   const sendNoticeAlarmMutation = useNoticeMutation(sendNoticeAlarm);
   const updateNoticePublicMutation = useNoticeMutation(updateNoticePublic);

--- a/src/hooks/queries/useNotice.ts
+++ b/src/hooks/queries/useNotice.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+
+import deleteNotice from '@/app/_api/notice/deleteNotice';
+import sendNoticeAlarm from '@/app/_api/notice/sendNoticeAlarm';
+import updateNoticePublic from '@/app/_api/notice/updateNoticePublic';
+
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+
+const useNoticeMutation = <TData = unknown, TError = unknown, TVariables = unknown>(
+  mutationFn: (variables: TVariables) => Promise<TData>,
+  mutationOptions?: Omit<UseMutationOptions<TData, TError, TVariables>, 'mutationFn'>
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.getAdminAllNotice] });
+    },
+    ...mutationOptions,
+  });
+};
+
+// React-query의 useMutation을 wrapping해주는 Notice 관련 custom hook
+const useNotice = () => {
+  const deletNoticeMutation = useNoticeMutation(deleteNotice);
+  const sendNoticeAlarmMutation = useNoticeMutation(sendNoticeAlarm);
+  const updateNoticePublicMutation = useNoticeMutation(updateNoticePublic);
+
+  return {
+    deletNoticeMutation,
+    sendNoticeAlarmMutation,
+    updateNoticePublicMutation,
+  };
+};
+
+export default useNotice;

--- a/src/hooks/queries/useNotice.ts
+++ b/src/hooks/queries/useNotice.ts
@@ -26,19 +26,19 @@ const useNoticeMutation = <TData = unknown, TError = unknown, TVariables = unkno
 // useNoticeMutation이 반환하는 타입은 UseMutationResult<TData, TError, TVariables, unknown> 타입으로,
 // useNotice 훅이 반환하는 각 함수의 반환값(void), 에러, 변수 타입(number), context 타입을 정의해주었다.
 type UseNoticeReturnType = {
-  deletNoticeMutation: UseMutationResult<void, unknown, number, unknown>;
+  deleteNoticeMutation: UseMutationResult<void, unknown, number, unknown>;
   sendNoticeAlarmMutation: UseMutationResult<void, unknown, number, unknown>;
   updateNoticePublicMutation: UseMutationResult<void, unknown, number, unknown>;
 };
 
 // React-query의 useMutation을 wrapping해주는 Notice 관련 custom hook
 const useNotice = (): UseNoticeReturnType => {
-  const deletNoticeMutation = useNoticeMutation(deleteNotice);
+  const deleteNoticeMutation = useNoticeMutation(deleteNotice);
   const sendNoticeAlarmMutation = useNoticeMutation(sendNoticeAlarm);
   const updateNoticePublicMutation = useNoticeMutation(updateNoticePublic);
 
   return {
-    deletNoticeMutation,
+    deleteNoticeMutation,
     sendNoticeAlarmMutation,
     updateNoticePublicMutation,
   };

--- a/src/lib/constants/queryKeys.ts
+++ b/src/lib/constants/queryKeys.ts
@@ -1,36 +1,54 @@
 export const QUERY_KEYS = {
+  // 사용자
   userOne: 'userOne',
+  getDefaultBackgroundImages: 'getDefaultBackgroundImages',
+  getDefaultProfileImages: 'getDefaultProfileImages',
+  getRecommendedUsers: 'getRecommendedUsers',
+
+  // 리스트
   createList: 'createList',
   uploadImage: 'uploadImage',
   getAllList: 'getAllList',
   getListDetail: 'getListDetail',
   getCategories: 'getCategories',
-  getComments: 'getComments',
   getRecommendedLists: 'getRecommendedLists',
   getRecentLists: 'getRecentLists',
   getFollowingLists: 'getFollowingLists',
-  getRecommendedUsers: 'getRecommendedUsers',
   getTrendingLists: 'getTrendingLists',
+  getComments: 'getComments',
+
+  // 알림
   getNotificationAllChecked: 'getNotificationOnAllChecked',
+  notifications: 'notifications',
+
+  // 팔로우
   follow: 'follow',
   deleteFollow: 'deleteFollow',
   deleteFollower: 'deleteFollower',
   getFollowingList: 'getFollowingList',
   getFollowerList: 'getFollowerList',
-  getUsersByNicknameSearch: 'getUsersByNicknameSearch',
-  notifications: 'notifications',
+
+  // 히스토리
   getHistories: 'getHistories',
   toggleHistoryPublic: 'toggleHistoryPublic',
   deleteHistory: 'deleteHistory',
-  getDefaultBackgroundImages: 'getDefaultBackgroundImages',
-  getDefaultProfileImages: 'getDefaultProfileImages',
+
+  // 검색
   searchListResult: 'searchListResult',
   searchUserResult: 'searchUserResult',
+  getUsersByNicknameSearch: 'getUsersByNicknameSearch',
+
+  // 콜렉션
   collect: 'collect',
   getCollection: 'getCollection',
   getFolders: 'getFolders',
   getCollectionCategories: 'getCollectionCategories', // ver2.0
-  getAdminTopics: 'getAdminTopics',
+
+  // 요청주제
   getTopics: 'getTopics',
+
+  // 어드민
+  getAdminTopics: 'getAdminTopics',
   getNoticeCategories: 'getNoticeCategories',
+  getAdminAllNotice: 'getAdminAllNotice',
 };

--- a/src/lib/constants/queryKeys.ts
+++ b/src/lib/constants/queryKeys.ts
@@ -49,6 +49,9 @@ export const QUERY_KEYS = {
 
   // 어드민
   getAdminTopics: 'getAdminTopics',
-  getNoticeCategories: 'getNoticeCategories',
   getAdminAllNotice: 'getAdminAllNotice',
+
+  // 공지
+  getNoticeCategories: 'getNoticeCategories',
+  getNoticeDetail: 'getNoticeDetail',
 };

--- a/src/lib/types/noticeType.ts
+++ b/src/lib/types/noticeType.ts
@@ -42,7 +42,7 @@ export type NoticeListItemType = NoticeType & {
 
 // 게시물 상세 조회
 export type NoticeDetailType = NoticeType & {
-  content: NoticeContentType[];
+  contents: NoticeContentType[];
   prevNotice: Partial<NoticeType>;
   nextNotice: Partial<NoticeType>;
 };

--- a/src/lib/types/noticeType.ts
+++ b/src/lib/types/noticeType.ts
@@ -20,34 +20,34 @@ export interface NoticeCreateType {
   contents: ItemsType[];
 }
 
-export interface NoticeListItemType {
+// 어드민 게시물 조회
+export type AdminNoticeType = Omit<NoticeListItemType, 'itemImageUrl'> & {
+  isExposed: boolean;
+  didSendAlarm: boolean;
+};
+
+// 게시물 타입
+interface NoticeType {
   id: number;
-  createdDate: string;
+  category: (typeof NOTICE_CATEGORY_NAME)[keyof typeof NOTICE_CATEGORY_NAME];
   title: string;
+  description: string;
+  createdDate: string;
+}
+
+// 게시물 리스트 조회
+export type NoticeListItemType = NoticeType & {
   itemImageUrl: string | null;
-  category: string;
-  description: string;
-}
+};
 
-export interface NoticeDetailType {
-  id: number;
-  category: string;
-  title: string;
-  description: string;
+// 게시물 상세 조회
+export type NoticeDetailType = NoticeType & {
   content: NoticeContentType[];
-  createdDate: string;
-  prevNotice: {
-    id: number;
-    title: string;
-    description: string;
-  };
-  nextNotice: {
-    id: number;
-    title: string;
-    description: string;
-  };
-}
+  prevNotice: Partial<NoticeType>;
+  nextNotice: Partial<NoticeType>;
+};
 
+// 게시물 내용(콘텐츠)
 export interface NoticeContentType {
   [key: string]: unknown;
   type: NoticeContentsType;


### PR DESCRIPTION
## 개요

- 어드민 게시물 조회 페이지를 구현했습니다.

<br>

## 작업 사항

- [x] 어드민 게시물 조회 페이지 UI 퍼블리싱
  - 마크업 시, 시멘틱 태그를 사용하여 웹 접근성 향상 
- [x] 게시물 **삭제** 기능 
- [x] 게시물 **알림 보내기** 기능
- [x] 게시물 **공개/비공개 옵션 변경** 기능  
- [x] 게시물 **미리보기** 기능 
  - [x] 미리보기 기능은 추후 사용자에게 보여지는 부분을 감안하여 공통 컴포넌트로 구현 
  - @Nahyun-Kang 나현님, 추후 사용자 게시물 페이지 구현하실 때 해당 컴포넌트 참고 부탁드립니다.
- [x] (리팩토링) 게시물 관련 **리액트쿼리 mutation 로직 커스텀 훅** 생성 `src/hooks/queries/useNotice.ts`
  - 하나의 페이지에서 삭제, 알림, 공개 수정의 뮤테이션 로직이 있다보니 중복된 로직이 발생하여, 리액트쿼리 mutation 부분을 커스텀훅으로 분리하였습니다. 추후 다른 부분에도 적용해보려고 합니다. 🫡

<br>

## 참고 사항 

### 후속 작업
- [ ] 게시물 수정하기 기능
 
<br>

## 스크린샷

### 어드민 게시물 페이지

![스크린샷 2024-11-28 오후 12 26 04](https://github.com/user-attachments/assets/81b8e40e-180a-4519-80f0-789af2592914)

### 미리보기 시 (스크롤)

#### 마크다운 에디터, 구분선, 이미지, 버튼
![스크린샷 2024-11-28 오후 12 26 31](https://github.com/user-attachments/assets/32213557-67f1-4aad-9e0d-8e76b72760d4)

#### 소제목, 마크다운 에디터, 구분선, 이미지, 유의
![스크린샷 2024-11-28 오후 12 26 48](https://github.com/user-attachments/assets/c948f103-5129-4199-8e00-abdc720aece4)

<br>

## 리뷰어에게

- 디자인 관련하여 피드백하실 부분 있으시면 말씀 부탁드립니다.🥹
- 공지 빨리 보내고 싶어요!! 🥳🥳

<br>
