### PR TITLE
Feat: 어드민 게시물 수정 기능 구현 및 드래그앤드롭 적용

### DIFF
--- a/src/app/_api/notice/updateNotice.ts
+++ b/src/app/_api/notice/updateNotice.ts
@@ -1,0 +1,13 @@
+import axiosInstance from '@/lib/axios/axiosInstance';
+import { NoticeCreateType } from '@/lib/types/noticeType';
+
+interface UpdateNoticeRequestType {
+  noticeData: NoticeCreateType;
+  noticeId: number;
+}
+
+const updateNotice = async ({ noticeData, noticeId }: UpdateNoticeRequestType) => {
+  await axiosInstance.put<ResponseType>(`/admin/notices/${noticeId}`, noticeData);
+};
+
+export default updateNotice;

--- a/src/app/admin/_components/NavLinks.css.ts
+++ b/src/app/admin/_components/NavLinks.css.ts
@@ -1,0 +1,21 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { BodyBold, BodyRegular } from '@/styles/font.css';
+import { vars } from '@/styles/theme.css';
+
+export const nav = style({
+  minWidth: 200,
+
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2rem',
+});
+
+export const variantLink = styleVariants({
+  default: [BodyRegular],
+  selected: [
+    BodyBold,
+    {
+      color: vars.color.blue,
+    },
+  ],
+});

--- a/src/app/admin/_components/NavLinks.tsx
+++ b/src/app/admin/_components/NavLinks.tsx
@@ -17,7 +17,11 @@ export default function NavLinks({ links }: NavLinksProps) {
       {links.map((link) => {
         const isActive = pathname && pathname.startsWith(link.path);
         return (
-          <Link href={link.path} className={isActive ? styles.variantLink.selected : styles.variantLink.default}>
+          <Link
+            key={link.path}
+            href={link.path}
+            className={isActive ? styles.variantLink.selected : styles.variantLink.default}
+          >
             {link.label}
           </Link>
         );

--- a/src/app/admin/_components/NavLinks.tsx
+++ b/src/app/admin/_components/NavLinks.tsx
@@ -5,27 +5,23 @@ import Link from 'next/link';
 
 import * as styles from './NavLinks.css';
 
-export default function NavLinks() {
+interface NavLinksProps {
+  links: Array<Record<string, string>>;
+}
+
+export default function NavLinks({ links }: NavLinksProps) {
   const pathname = usePathname();
 
   return (
     <nav className={styles.nav}>
-      <Link
-        href="/admin/topics"
-        className={
-          pathname && pathname.startsWith('/admin/topics') ? styles.variantLink.selected : styles.variantLink.default
-        }
-      >
-        요청 주제
-      </Link>
-      <Link
-        href="/admin/notice"
-        className={
-          pathname && pathname.startsWith('/admin/notice') ? styles.variantLink.selected : styles.variantLink.default
-        }
-      >
-        게시물
-      </Link>
+      {links.map((link) => {
+        const isActive = pathname && pathname.startsWith(link.path);
+        return (
+          <Link href={link.path} className={isActive ? styles.variantLink.selected : styles.variantLink.default}>
+            {link.label}
+          </Link>
+        );
+      })}
     </nav>
   );
 }

--- a/src/app/admin/_components/NavLinks.tsx
+++ b/src/app/admin/_components/NavLinks.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+
+import * as styles from './NavLinks.css';
+
+export default function NavLinks() {
+  const pathname = usePathname();
+
+  return (
+    <nav className={styles.nav}>
+      <Link
+        href="/admin/topics"
+        className={
+          pathname && pathname.startsWith('/admin/topics') ? styles.variantLink.selected : styles.variantLink.default
+        }
+      >
+        요청 주제
+      </Link>
+      <Link
+        href="/admin/notice"
+        className={
+          pathname && pathname.startsWith('/admin/notice') ? styles.variantLink.selected : styles.variantLink.default
+        }
+      >
+        게시물
+      </Link>
+    </nav>
+  );
+}

--- a/src/app/admin/layout.css.ts
+++ b/src/app/admin/layout.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { Header, BodyRegular } from '@/styles/font.css';
+import { Header } from '@/styles/font.css';
 import { vars } from '@/styles/theme.css';
 
 export const container = style({
@@ -8,11 +8,11 @@ export const container = style({
 });
 
 export const nav = style({
-  padding: '1.5rem',
+  padding: '1rem',
 
   display: 'flex',
   flexDirection: 'column',
-  gap: '3rem',
+  gap: '2rem',
 
   borderRight: '2px solid',
   borderRightColor: vars.color.bluegray6,
@@ -22,16 +22,6 @@ export const title = style([
   Header,
   {
     color: vars.color.bluegray8,
-  },
-]);
-
-export const menu = style([
-  BodyRegular,
-  {
-    width: 200,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '2rem',
   },
 ]);
 

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 import * as styles from './layout.css';
-import Link from 'next/link';
+import NavLinks from './_components/NavLinks';
 
 interface AdminNoticeLayoutProps {
   children: ReactNode;
@@ -10,13 +10,10 @@ interface AdminNoticeLayoutProps {
 export default function AdminNoticeLayout({ children }: AdminNoticeLayoutProps) {
   return (
     <section className={styles.container}>
-      <nav className={styles.nav}>
+      <div className={styles.nav}>
         <h1 className={styles.title}>🤍 리스티웨이브 관리</h1>
-        <ul className={styles.menu}>
-          <Link href="/admin/topics">요청 주제</Link>
-          <Link href="/admin/notice">게시물</Link>
-        </ul>
-      </nav>
+        <NavLinks />
+      </div>
       <main className={styles.main}>{children}</main>
     </section>
   );

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -12,7 +12,18 @@ export default function AdminNoticeLayout({ children }: AdminNoticeLayoutProps) 
     <section className={styles.container}>
       <div className={styles.nav}>
         <h1 className={styles.title}>🤍 리스티웨이브 관리</h1>
-        <NavLinks />
+        <NavLinks
+          links={[
+            {
+              label: '요청 주제',
+              path: '/admin/topics',
+            },
+            {
+              label: '게시물',
+              path: '/admin/notice',
+            },
+          ]}
+        />
       </div>
       <main className={styles.main}>{children}</main>
     </section>

--- a/src/app/admin/notice/[noticeId]/edit/page.tsx
+++ b/src/app/admin/notice/[noticeId]/edit/page.tsx
@@ -9,59 +9,16 @@ import * as styles from '../../create/page.css';
 
 import updateNotice from '@/app/_api/notice/updateNotice';
 import uploadNoticeImages from '@/app/_api/notice/uploadNoticeImages';
+import getNoticeDetail from '@/app/_api/notice/getNoticeDetail';
 
 import { NoticeCreateType, NoticeDetailType } from '@/lib/types/noticeType';
 import { noticeDescriptionRules, noticeTitleRules } from '@/lib/constants/formInputValidationRules';
+import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+import { NOTICE_CATEGORY_NAME } from '@/lib/constants/notice';
+import { formatImageData, formatNoticeData } from '@/lib/utils/formatDataForNotice';
 
 import CategoryDropdown from '../../create/_components/CategoryDropdown';
 import ContentsBody from '../../create/_components/ContentsBody';
-import getNoticeDetail from '@/app/_api/notice/getNoticeDetail';
-import { QUERY_KEYS } from '@/lib/constants/queryKeys';
-import { NOTICE_CATEGORY_NAME } from '@/lib/constants/notice';
-
-/** 공지 작성 데이터 포맷 유틸 함수 */
-const formatNoticeData = (originData: NoticeCreateType) => {
-  // order 정리 및 이미지 url 초기화
-  const updatedContents = originData.contents.map((item, index) => {
-    const newContents = { ...item, order: index + 1 };
-    if (newContents.type === 'image') {
-      if (typeof newContents.imageUrl !== 'string') {
-        newContents.imageUrl = '';
-      }
-    }
-    return newContents;
-  });
-
-  // 새로운 데이터 객체 반환
-  const noticeData: NoticeCreateType = {
-    ...originData,
-    contents: updatedContents,
-  };
-  return noticeData;
-};
-
-/** 이미지 업로드 데이터 포맷 유틸 함수 */
-const formatImageData = (originData: NoticeCreateType) => {
-  const imageExtensionData = originData.contents
-    .map((item, index) => {
-      return { ...item, order: index + 1 };
-    })
-    .filter((item) => item.type === 'image' && typeof item.imageUrl !== 'string')
-    .map(({ order, imageUrl }) => {
-      return {
-        order: order,
-        extension: (imageUrl as File).type.split('/')[1],
-      };
-    });
-
-  const imageFileData = originData.contents
-    .filter((item) => item.type === 'image' && typeof item.imageUrl !== 'string')
-    .map((item) => {
-      return item.imageUrl as File;
-    });
-
-  return { imageExtensionData, imageFileData };
-};
 
 type NoticeCategoryNameType = (typeof NOTICE_CATEGORY_NAME)[keyof typeof NOTICE_CATEGORY_NAME];
 

--- a/src/app/admin/notice/_components/NoticeItem.css.ts
+++ b/src/app/admin/notice/_components/NoticeItem.css.ts
@@ -35,6 +35,8 @@ export const buttons = style({
   display: 'flex',
   justifyContent: 'center',
   gap: '0.5rem',
+
+  whiteSpace: 'nowrap',
 });
 
 const button = style({
@@ -42,6 +44,8 @@ const button = style({
   borderRadius: '4px',
   backgroundColor: vars.color.blue,
   color: vars.color.white,
+
+  whiteSpace: 'nowrap',
 
   ':hover': {
     opacity: 0.7,

--- a/src/app/admin/notice/_components/NoticeItem.tsx
+++ b/src/app/admin/notice/_components/NoticeItem.tsx
@@ -4,6 +4,7 @@ import * as styles from './NoticeItem.css';
 
 import useNotice from '@/hooks/queries/useNotice';
 import useBooleanOutput from '@/hooks/useBooleanOutput';
+import useMoveToPage from '@/hooks/useMoveToPage';
 
 import Modal from '@/components/Modal/Modal';
 import NoticeDetailInfo from '@/components/NoticeDetail/NoticeDetailInfo';
@@ -35,6 +36,7 @@ interface NoticeItemProps {
 function NoticeItem({ notice }: NoticeItemProps) {
   const { deleteNoticeMutation, sendNoticeAlarmMutation, updateNoticePublicMutation } = useNotice();
   const { isOn, handleSetOn, handleSetOff } = useBooleanOutput();
+  const { onClickMoveToPage } = useMoveToPage();
 
   const { id, title, description, didSendAlarm, isExposed, category, createdDate } = notice;
 
@@ -70,7 +72,9 @@ function NoticeItem({ notice }: NoticeItemProps) {
           <span className={styles.rowText}>{description}</span>
         </td>
         <td className={styles.buttons}>
-          <button className={styles.variantsButton.default}>수정</button>
+          <button onClick={onClickMoveToPage(`/admin/notice/${id}/edit`)} className={styles.variantsButton.default}>
+            수정
+          </button>
           <button className={styles.variantsButton.default} onClick={handleDeleteNotice}>
             삭제
           </button>

--- a/src/app/admin/notice/create/_components/BlockContainer.css.ts
+++ b/src/app/admin/notice/create/_components/BlockContainer.css.ts
@@ -15,6 +15,18 @@ export const wrapper = style({
   alignItems: 'center',
 });
 
+export const titleWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1rem',
+});
+
+export const drag = style({
+  padding: '0.5rem',
+  borderRadius: '0.5rem',
+  border: `1px solid ${vars.color.lightgray}`,
+});
+
 export const title = style([BodyRegular]);
 
 export const deleteButton = style({

--- a/src/app/admin/notice/create/_components/BlockContainer.tsx
+++ b/src/app/admin/notice/create/_components/BlockContainer.tsx
@@ -1,4 +1,6 @@
+import Image from 'next/image';
 import { FieldArrayWithId } from 'react-hook-form';
+import { DraggableProvided } from '@hello-pangea/dnd';
 
 import * as styles from './BlockContainer.css';
 
@@ -34,15 +36,21 @@ interface ContainerProps {
   content: FieldArrayWithId<NoticeCreateType, 'contents', 'id'>;
   handleDeleteBlock: (order: number) => void;
   order: number;
+  provided: DraggableProvided;
 }
 
-export default function ContentsContainer({ content, handleDeleteBlock, order }: ContainerProps) {
+export default function ContentsContainer({ content, handleDeleteBlock, order, provided }: ContainerProps) {
   const { type } = content;
 
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
-        <h3 className={styles.title}>{NOTICE_CONTENT[type]}</h3>
+        <div className={styles.titleWrapper}>
+          <div {...provided.dragHandleProps} className={styles.drag}>
+            <Image src={'/icons/dnd.svg'} width={22} height={15} alt="drag and drop" />
+          </div>
+          <h3 className={styles.title}>{NOTICE_CONTENT[type]}</h3>
+        </div>
         <button type="button" onClick={() => handleDeleteBlock(order)} className={styles.deleteButton}>
           삭제
         </button>

--- a/src/app/admin/notice/create/_components/BlockContainer.tsx
+++ b/src/app/admin/notice/create/_components/BlockContainer.tsx
@@ -39,7 +39,7 @@ interface ContainerProps {
   provided: DraggableProvided;
 }
 
-export default function ContentsContainer({ content, handleDeleteBlock, order, provided }: ContainerProps) {
+export default function BlockContainer({ content, handleDeleteBlock, order, provided }: ContainerProps) {
   const { type } = content;
 
   return (

--- a/src/app/admin/notice/create/_components/CategoryDropdown.tsx
+++ b/src/app/admin/notice/create/_components/CategoryDropdown.tsx
@@ -5,12 +5,13 @@ import * as styles from './CategoryDropdown.css';
 
 import getNoticeCategories from '@/app/_api/notice/getNoticeCategories';
 import { QUERY_KEYS } from '@/lib/constants/queryKeys';
+import { NoticeCategoryType } from '@/lib/types/noticeType';
 
 export default function CategoryDropdown() {
   const { register } = useFormContext();
 
   /** 게시물 카테고리 조회 */
-  const { data: categories } = useQuery({
+  const { data: categories } = useQuery<NoticeCategoryType[]>({
     queryKey: [QUERY_KEYS.getNoticeCategories],
     queryFn: getNoticeCategories,
     staleTime: Infinity,

--- a/src/app/admin/notice/create/_components/ContentsBody.css.ts
+++ b/src/app/admin/notice/create/_components/ContentsBody.css.ts
@@ -8,6 +8,18 @@ export const contents = style({
   gap: 6,
 });
 
+export const item = style({
+  transition: 'box-shadow 0.3s ease',
+});
+
+export const draggingItem = style([
+  item,
+  {
+    backgroundColor: vars.color.lightblue,
+    boxShadow: 'rgba(0, 0, 0, 0.1) 0px 4px 6px -1px, rgba(0, 0, 0, 0.06) 0px 2px 4px -1px',
+  },
+]);
+
 export const block = style({
   padding: '0.5rem',
   borderRadius: 4,

--- a/src/app/admin/notice/create/_components/ContentsBody.tsx
+++ b/src/app/admin/notice/create/_components/ContentsBody.tsx
@@ -74,8 +74,12 @@ export default function ContentsBody() {
               <div ref={provided.innerRef} {...provided.droppableProps}>
                 {fields.map((field, index) => (
                   <Draggable key={field.id} draggableId={field.id} index={index}>
-                    {(provided) => (
-                      <div ref={provided.innerRef} {...provided.draggableProps}>
+                    {(provided, snapshot) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.draggableProps}
+                        className={snapshot.isDragging ? styles.draggingItem : styles.item}
+                      >
                         <ContentsContainer
                           key={field.id}
                           content={field as ItemsType & { id: string }}

--- a/src/app/admin/notice/create/_components/ContentsBody.tsx
+++ b/src/app/admin/notice/create/_components/ContentsBody.tsx
@@ -1,4 +1,5 @@
 import { useFieldArray, useFormContext } from 'react-hook-form';
+import { DragDropContext, Draggable, DropResult } from '@hello-pangea/dnd';
 
 import * as styles from './ContentsBody.css';
 
@@ -6,6 +7,7 @@ import { NOTICE_CONTENT } from '@/lib/constants/notice';
 import { ItemsType, NoticeContentsType } from '@/lib/types/noticeType';
 
 import ContentsContainer from './BlockContainer';
+import { StrictModeDroppable } from '@/components/StrictModeDroppable';
 
 /** 타입에 따른 Contents 블럭 포멧 지정 유틸 함수 */
 const itemDataFormatByType = (type: NoticeContentsType) => {
@@ -47,18 +49,40 @@ export default function ContentsBody() {
     remove(order);
   };
 
+  // TODO 드래그 종료시 실행될 함수
+  const handleOnDragEnd = ({ draggableId, source, destination }: DropResult) => {
+    console.log(draggableId, source, destination);
+  };
+
   return (
     <>
       <section>
-        {fields.map((field, index) => (
-          <ContentsContainer
-            key={field.id}
-            content={field as ItemsType & { id: string }}
-            order={index}
-            handleDeleteBlock={handleDeleteBlock}
-          />
-        ))}
+        <DragDropContext onDragEnd={handleOnDragEnd}>
+          <StrictModeDroppable droppableId="items">
+            {(provided) => (
+              <div ref={provided.innerRef} {...provided.droppableProps}>
+                {fields.map((field, index) => (
+                  <Draggable key={field.id} draggableId={field.id} index={index}>
+                    {(provided) => (
+                      <div ref={provided.innerRef} {...provided.draggableProps}>
+                        <ContentsContainer
+                          key={field.id}
+                          content={field as ItemsType & { id: string }}
+                          order={index}
+                          handleDeleteBlock={handleDeleteBlock}
+                          provided={provided}
+                        />
+                      </div>
+                    )}
+                  </Draggable>
+                ))}
+                {provided.placeholder}
+              </div>
+            )}
+          </StrictModeDroppable>
+        </DragDropContext>
       </section>
+
       <section className={styles.contents}>
         {Object.entries(NOTICE_CONTENT).map(([key, value], index) => (
           <button

--- a/src/app/admin/notice/create/_components/ContentsBody.tsx
+++ b/src/app/admin/notice/create/_components/ContentsBody.tsx
@@ -6,7 +6,7 @@ import * as styles from './ContentsBody.css';
 import { NOTICE_CONTENT } from '@/lib/constants/notice';
 import { ItemsType, NoticeContentsType } from '@/lib/types/noticeType';
 
-import ContentsContainer from './BlockContainer';
+import BlockContainer from './BlockContainer';
 import { StrictModeDroppable } from '@/components/StrictModeDroppable';
 
 /** 타입에 따른 Contents 블럭 포멧 지정 유틸 함수 */
@@ -80,7 +80,7 @@ export default function ContentsBody() {
                         {...provided.draggableProps}
                         className={snapshot.isDragging ? styles.draggingItem : styles.item}
                       >
-                        <ContentsContainer
+                        <BlockContainer
                           key={field.id}
                           content={field as ItemsType & { id: string }}
                           order={index}

--- a/src/app/admin/notice/create/_components/ContentsBody.tsx
+++ b/src/app/admin/notice/create/_components/ContentsBody.tsx
@@ -35,7 +35,7 @@ const itemDataFormatByType = (type: NoticeContentsType) => {
 };
 
 export default function ContentsBody() {
-  const { control } = useFormContext();
+  const { setValue, getValues, control } = useFormContext();
   const { fields, append, remove } = useFieldArray({
     name: 'contents',
     control,
@@ -49,16 +49,27 @@ export default function ContentsBody() {
     remove(order);
   };
 
-  // TODO 드래그 종료시 실행될 함수
-  const handleOnDragEnd = ({ draggableId, source, destination }: DropResult) => {
-    console.log(draggableId, source, destination);
+  // 드래그앤드롭 시 실행될 함수
+  const handleOnDragEnd = ({ source, destination }: DropResult) => {
+    if (!destination) return;
+
+    const currentFields = getValues('contents');
+    const draggingFieldIndex = source.index;
+    const dropFieldIndex = destination.index;
+
+    // 드래그한 필드를 기존 배열에서 삭제
+    const removeField = currentFields.splice(draggingFieldIndex, 1);
+    // 드롭한 위치에 드래그한 필드를 추가
+    currentFields.splice(dropFieldIndex, 0, removeField[0]);
+    // 전체 필드 업데이트
+    setValue('contents', currentFields);
   };
 
   return (
     <>
       <section>
         <DragDropContext onDragEnd={handleOnDragEnd}>
-          <StrictModeDroppable droppableId="items">
+          <StrictModeDroppable droppableId="fields">
             {(provided) => (
               <div ref={provided.innerRef} {...provided.droppableProps}>
                 {fields.map((field, index) => (

--- a/src/app/admin/notice/create/_components/block/BodyContent.tsx
+++ b/src/app/admin/notice/create/_components/block/BodyContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import MDEditor from '@uiw/react-md-editor';
 import { useFormContext } from 'react-hook-form';
 
@@ -10,7 +10,7 @@ interface BodyContentProps {
 
 // TODO security
 export default function BodyContent({ order }: BodyContentProps) {
-  const { setValue } = useFormContext();
+  const { setValue, getValues } = useFormContext();
   const [text, setText] = useState('');
 
   const handleChange = useCallback((value?: string) => {
@@ -21,6 +21,13 @@ export default function BodyContent({ order }: BodyContentProps) {
     setValue(`contents.${order}.description`, text);
     alert('본문을 저장했습니다.');
   };
+
+  useEffect(() => {
+    const markdownValue = getValues(`contents.${order}.description`);
+    if (markdownValue) {
+      setText(markdownValue);
+    }
+  }, [order, getValues]);
 
   return (
     <>

--- a/src/app/admin/notice/create/_components/block/ImageContent.tsx
+++ b/src/app/admin/notice/create/_components/block/ImageContent.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, MouseEvent, useRef, useState } from 'react';
+import { ChangeEvent, MouseEvent, useEffect, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import * as styles from './index.css';
@@ -14,7 +14,7 @@ interface ImageContentProps {
 export default function ImageContent({ order }: ImageContentProps) {
   const fileRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState('');
-  const { setValue } = useFormContext();
+  const { setValue, getValues } = useFormContext();
 
   const handleUploadFile = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -29,6 +29,13 @@ export default function ImageContent({ order }: ImageContentProps) {
     setValue(`contents.${order}.imageUrl`, '');
     setPreviewImage('');
   };
+
+  useEffect(() => {
+    const image = getValues(`contents.${order}.imageUrl`);
+    if (image) {
+      fileToBase64(image, setPreviewImage);
+    }
+  }, [getValues, order]);
 
   return (
     <>

--- a/src/app/admin/notice/create/_components/block/ImageContent.tsx
+++ b/src/app/admin/notice/create/_components/block/ImageContent.tsx
@@ -33,6 +33,10 @@ export default function ImageContent({ order }: ImageContentProps) {
   useEffect(() => {
     const image = getValues(`contents.${order}.imageUrl`);
     if (image) {
+      if (typeof image === 'string') {
+        setPreviewImage(image);
+        return;
+      }
       fileToBase64(image, setPreviewImage);
     }
   }, [getValues, order]);

--- a/src/app/admin/notice/create/page.tsx
+++ b/src/app/admin/notice/create/page.tsx
@@ -12,53 +12,10 @@ import uploadNoticeImages from '@/app/_api/notice/uploadNoticeImages';
 
 import { NoticeCreateType } from '@/lib/types/noticeType';
 import { noticeDescriptionRules, noticeTitleRules } from '@/lib/constants/formInputValidationRules';
+import { formatImageData, formatNoticeData } from '@/lib/utils/formatDataForNotice';
 
 import CategoryDropdown from './_components/CategoryDropdown';
 import ContentsBody from './_components/ContentsBody';
-
-/** 공지 작성 데이터 포맷 유틸 함수 */
-const formatNoticeData = (originData: NoticeCreateType) => {
-  // order 정리 및 이미지 url 초기화
-  const updatedContents = originData.contents.map((item, index) => {
-    const newContents = { ...item, order: index + 1 };
-    if (newContents.type === 'image') {
-      if (typeof newContents.imageUrl !== 'string') {
-        newContents.imageUrl = '';
-      }
-    }
-    return newContents;
-  });
-
-  // 새로운 데이터 객체 반환
-  const noticeData: NoticeCreateType = {
-    ...originData,
-    contents: updatedContents,
-  };
-  return noticeData;
-};
-
-/** 이미지 업로드 데이터 포맷 유틸 함수 */
-const formatImageData = (originData: NoticeCreateType) => {
-  const imageExtensionData = originData.contents
-    .map((item, index) => {
-      return { ...item, order: index + 1 };
-    })
-    .filter((item) => item.type === 'image' && typeof item.imageUrl !== 'string')
-    .map(({ order, imageUrl }) => {
-      return {
-        order: order,
-        extension: (imageUrl as File).type.split('/')[1],
-      };
-    });
-
-  const imageFileData = originData.contents
-    .filter((item) => item.type === 'image' && typeof item.imageUrl !== 'string')
-    .map((item) => {
-      return item.imageUrl as File;
-    });
-
-  return { imageExtensionData, imageFileData };
-};
 
 export default function CreateNotice() {
   const router = useRouter();

--- a/src/app/admin/notice/page.css.ts
+++ b/src/app/admin/notice/page.css.ts
@@ -1,11 +1,33 @@
 import { style } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
-import { BodyRegular } from '@/styles/font.css';
+import { Body, BodyRegular } from '@/styles/font.css';
 
 export const page = style({
   padding: '1.5rem',
   height: '100%',
 });
+
+export const button = style({
+  display: 'flex',
+  flexDirection: 'row-reverse',
+  marginBottom: '1rem',
+});
+
+export const plusNoticeButton = style([
+  Body,
+  {
+    padding: '0.5rem 1rem',
+    borderRadius: '4px',
+    backgroundColor: vars.color.blue,
+    color: vars.color.white,
+
+    whiteSpace: 'nowrap',
+
+    ':hover': {
+      opacity: 0.7,
+    },
+  },
+]);
 
 export const table = style({
   maxWidth: '850px',

--- a/src/app/admin/notice/page.css.ts
+++ b/src/app/admin/notice/page.css.ts
@@ -8,6 +8,8 @@ export const page = style({
 });
 
 export const button = style({
+  maxWidth: '850px',
+
   display: 'flex',
   flexDirection: 'row-reverse',
   marginBottom: '1rem',

--- a/src/app/admin/notice/page.tsx
+++ b/src/app/admin/notice/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 
 import * as styles from './page.css';
@@ -21,6 +22,11 @@ export default function AdminNoticesPage() {
 
   return (
     <section className={styles.page}>
+      <div className={styles.button}>
+        <Link href="/admin/notice/create" className={styles.plusNoticeButton}>
+          + 작성하기
+        </Link>
+      </div>
       <table className={styles.table}>
         <thead>
           <tr className={styles.headRow}>

--- a/src/app/admin/topics/page.tsx
+++ b/src/app/admin/topics/page.tsx
@@ -1,0 +1,9 @@
+// 임시 요청 주제 페이지
+
+export default function AdminTopicsPage() {
+  return (
+    <section>
+      <h1>요청 주제 페이지</h1>
+    </section>
+  );
+}

--- a/src/components/NoticeDetail/NoticeDetailContents.css.ts
+++ b/src/components/NoticeDetail/NoticeDetailContents.css.ts
@@ -17,6 +17,7 @@ export const imgaeBox = style({
 
 export const image = style({
   objectFit: 'cover',
+  borderRadius: '5px',
 });
 
 export const button = style([

--- a/src/components/NoticeDetail/NoticeDetailInfo.css.ts
+++ b/src/components/NoticeDetail/NoticeDetailInfo.css.ts
@@ -1,7 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
 import { vars } from '@/styles/theme.css';
-import { Label } from '@/styles/font.css';
+import { LabelBold } from '@/styles/font.css';
 
 export const info = style({
   padding: '25px 16px 40px',
@@ -13,7 +13,7 @@ export const info = style({
 });
 
 export const category = style([
-  Label,
+  LabelBold,
   {
     width: 'fit-content',
     padding: '6px 12px',

--- a/src/lib/utils/formatDataForNotice.ts
+++ b/src/lib/utils/formatDataForNotice.ts
@@ -1,0 +1,47 @@
+import { NoticeCreateType } from '@/lib/types/noticeType';
+
+/** 어드민 게시물 생성 데이터 포맷 함수 */
+const formatNoticeData = (originData: NoticeCreateType) => {
+  // 콘텐츠 블록 order 정리 및 이미지 url 초기화
+  const updatedContents = originData.contents.map((item, index) => {
+    const newContents = { ...item, order: index + 1 };
+    if (newContents.type === 'image') {
+      if (typeof newContents.imageUrl !== 'string') {
+        newContents.imageUrl = '';
+      }
+    }
+    return newContents;
+  });
+
+  // 새로운 데이터 객체 반환
+  const noticeData: NoticeCreateType = {
+    ...originData,
+    contents: updatedContents,
+  };
+  return noticeData;
+};
+
+/** 이미지 업로드 데이터 포맷 함수 */
+const formatImageData = (originData: NoticeCreateType) => {
+  const imageExtensionData = originData.contents
+    .map((item, index) => {
+      return { ...item, order: index + 1 };
+    })
+    .filter((item) => item.type === 'image' && typeof item.imageUrl !== 'string')
+    .map(({ order, imageUrl }) => {
+      return {
+        order: order,
+        extension: (imageUrl as File).type.split('/')[1],
+      };
+    });
+
+  const imageFileData = originData.contents
+    .filter((item) => item.type === 'image' && typeof item.imageUrl !== 'string')
+    .map((item) => {
+      return item.imageUrl as File;
+    });
+
+  return { imageExtensionData, imageFileData };
+};
+
+export { formatNoticeData, formatImageData };


### PR DESCRIPTION
## 개요

- 어드민 페이지 게시물 수정 기능을 구현했습니다.
- 콘텐츠 블록에 드래그앤드롭 기능을 적용했습니다.

<br>

## 작업 사항

- [x] 게시물 작성 시 콘텐츠 블록에 `드래그앤드롭` 기능 적용
- [x] 게시물 수정 기능 구현
  - 기존에 작성한 데이터 정보(제목, 이미지, 순서 등)가 보여지고, 수정, 추가 및 삭제하여 게시물을 수정할 수 있습니다.
  - 수정 API 연동, 관련 UI 마크업
  - `react-hook-form`을 사용하여 form 로직 관리
  - (참고) 이미지를 수정하지 않을 경우에는 기존 url을 그대로 저장하고, 수정이 이루어질때는 게시물 생성과 동일하게 pre-signed url 방식으로 이미지를 업로드 합니다.
- [x] (리팩토링) 어드민 게시물 작성과 수정에 **공통**으로 사용되는 데이터 형식, 이미지 형식 관련 유틸 함수를 재사용 가능하도록 분리하였습니다.
- [x] (스타일) 어드민 nav 메뉴 active 스타일 적용

<br>

## 스크린샷

### 어드민 게시물탭 전체 페이지
<img width="1101" alt="image" src="https://github.com/user-attachments/assets/3cf6faee-7d20-4726-ac13-66bdb78fa214">

### 수정페이지 (게시물 작성페이지와 동일합니다.)

<br>

## 리뷰어에게

- 확인 부탁드립니다. ❄️☃️☃️❄️

<br>
