### PR TITLE
Fix: 리스트 생성,수정 오류 수정

### DIFF
--- a/src/app/(home)/_components/TopicsRecommendation.tsx
+++ b/src/app/(home)/_components/TopicsRecommendation.tsx
@@ -49,7 +49,8 @@ function TopicItem({ title }: TopicItemProps) {
   const router = useRouter();
 
   const handleTopicClick = (title: string) => {
-    router.push(`/list/create?title=${title}`);
+    const encodedTitle = encodeURIComponent(title);
+    router.push(`/list/create?title=${encodedTitle}`);
   };
 
   return (

--- a/src/app/list/[listId]/edit/page.tsx
+++ b/src/app/list/[listId]/edit/page.tsx
@@ -91,7 +91,7 @@ export default function EditPage() {
   //데이터 채워넣기
   useEffect(() => {
     initializeFormValues();
-  }, [listDetailData, categories, user.id]); //gpt: 여기 dependency list에 빼야할 게 있을까?
+  }, [listDetailData, categories, user.id]);
 
   /** Request 보내기 */
   //--- 포맷 맞추기

--- a/src/app/list/[listId]/edit/page.tsx
+++ b/src/app/list/[listId]/edit/page.tsx
@@ -34,8 +34,21 @@ export default function EditPage() {
   const handleNext = () => setStep((prev) => prev + 1);
   const handleBack = () => setStep((prev) => prev - 1);
 
-  /** React Hook Form */
-  //-- 초기세팅
+  //--- 기존 데이터 불러오기
+  // 카테고리 목록
+  const { data: categories } = useQuery<CategoryType[]>({
+    queryKey: [QUERY_KEYS.getCategories],
+    queryFn: () => getCategories(),
+  });
+
+  //기존 리스트 데이터
+  const { data: listDetailData } = useQuery<ListDetailType>({
+    queryKey: [QUERY_KEYS.getListDetail, param?.listId],
+    queryFn: () => getListDetail(Number(param?.listId)),
+  });
+
+  /** 초기 세팅 */
+  //-- React-Hook-Form
   const methods = useForm<ListCreateType>({
     mode: 'onChange',
     defaultValues: {
@@ -51,21 +64,8 @@ export default function EditPage() {
     },
   });
 
-  //--- 기존 데이터 불러오기
-  //기존 리스트 데이터
-  const { data: listDetailData } = useQuery<ListDetailType>({
-    queryKey: [QUERY_KEYS.getListDetail, param?.listId],
-    queryFn: () => getListDetail(Number(param?.listId)),
-  });
-
-  // 카테고리 목록
-  const { data: categories } = useQuery<CategoryType[]>({
-    queryKey: [QUERY_KEYS.getCategories],
-    queryFn: () => getCategories(),
-  });
-
-  //데이터 채워넣기
-  useEffect(() => {
+  //기존 데이터로 채우기
+  const initializeFormValues = () => {
     if (listDetailData) {
       methods.reset({
         category: categories?.find((category) => category.korName === listDetailData.categoryKorName)?.engName,
@@ -76,21 +76,22 @@ export default function EditPage() {
         isPublic: listDetailData.isPublic,
         backgroundPalette: listDetailData.backgroundPalette,
         backgroundColor: listDetailData.backgroundColor,
-        items: listDetailData.items.map(({ id, rank, title, comment, link, imageUrl }) => {
-          return {
-            rank: rank,
-            id: id,
-            title: title,
-            comment: comment ? comment : '',
-            link: link ? link : '',
-            imageUrl: typeof imageUrl === 'string' ? imageUrl : '',
-          };
-        }),
+        items: listDetailData.items.map(({ id, rank, title, comment, link, imageUrl }) => ({
+          rank,
+          id,
+          title,
+          comment: comment || '',
+          link: link || '',
+          imageUrl: typeof imageUrl === 'string' ? imageUrl : '',
+        })),
       });
     }
+  };
 
-    methods.trigger(['title']);
-  }, [listDetailData, categories, methods, user.id]);
+  //데이터 채워넣기
+  useEffect(() => {
+    initializeFormValues();
+  }, [listDetailData, categories, user.id]); //gpt: 여기 dependency list에 빼야할 게 있을까?
 
   /** Request 보내기 */
   //--- 포맷 맞추기

--- a/src/app/list/create/_components/ItemAccordion.css.ts
+++ b/src/app/list/create/_components/ItemAccordion.css.ts
@@ -45,8 +45,8 @@ export const variantRankBadge = styleVariants({
 export const titleInput = style([
   fonts.BodyBold,
   {
-    flexGrow: 1, //남는 공간 차지하게
-    minWidth: '0', //부모컨테이너에 맞춰 줄어들 수 있도록 강제 (안넣을 경우 내용에 맞춰서 크기 유지)
+    flexGrow: 1,
+    minWidth: '0',
 
     color: vars.color.bluegray10,
     '::placeholder': { color: vars.color.bluegray6 },
@@ -61,7 +61,7 @@ export const accordionIconWrapper = style({
 
   width: '2rem',
   height: '2.6rem',
-  flexShrink: 0, //아이콘은 줄어들지 않도록 설정
+  flexShrink: 0,
 });
 
 //콘텐트

--- a/src/app/list/create/_components/ItemAccordion.css.ts
+++ b/src/app/list/create/_components/ItemAccordion.css.ts
@@ -20,30 +20,34 @@ export const header = style({
   color: vars.color.red,
 });
 
-export const rank = style([
+const rankBadge = style([
   fonts.Label,
   {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    width: '4.2rem',
+    minWidth: '4.2rem',
     height: '2.6rem',
 
     color: vars.color.blue,
     backgroundColor: vars.color.lightblue,
     borderRadius: '1.5rem',
+
+    whiteSpace: 'nowrap',
   },
 ]);
 
-export const variantRank = styleVariants({
-  default: [rank],
-  first: [rank, { color: vars.color.white, backgroundColor: vars.color.blue }],
+export const variantRankBadge = styleVariants({
+  default: [rankBadge],
+  first: [rankBadge, { color: vars.color.white, backgroundColor: vars.color.blue }],
 });
 
 export const titleInput = style([
   fonts.BodyBold,
   {
-    flexGrow: 1,
+    flexGrow: 1, //남는 공간 차지하게
+    minWidth: '0', //부모컨테이너에 맞춰 줄어들 수 있도록 강제 (안넣을 경우 내용에 맞춰서 크기 유지)
+
     color: vars.color.bluegray10,
     '::placeholder': { color: vars.color.bluegray6 },
   },
@@ -57,6 +61,7 @@ export const accordionIconWrapper = style({
 
   width: '2rem',
   height: '2.6rem',
+  flexShrink: 0, //아이콘은 줄어들지 않도록 설정
 });
 
 //콘텐트

--- a/src/app/list/create/_components/ItemAccordion.css.ts
+++ b/src/app/list/create/_components/ItemAccordion.css.ts
@@ -67,8 +67,9 @@ export const accordionIconWrapper = style({
 //콘텐트
 export const hr = style({
   width: '100%',
-  strokeWidth: '0.4rem ',
-  stroke: vars.color.bluegray8,
+  height: '0.4px',
+  backgroundColor: vars.color.bluegray6,
+  border: 0,
 });
 
 export const content = style({

--- a/src/app/list/create/_components/ItemAccordion.tsx
+++ b/src/app/list/create/_components/ItemAccordion.tsx
@@ -94,7 +94,7 @@ export default function ItemAccordion({
     <div className={styles.accordion}>
       <div className={styles.header}>
         <Image src={'/icons/dnd.svg'} width={16} height={13} alt="drag and drop" />
-        <div className={rank === 1 ? styles.variantRank.first : styles.variantRank.default}>{rank}위</div>
+        <div className={rank === 1 ? styles.variantRankBadge.first : styles.variantRankBadge.default}>{rank}위</div>
         <input
           {...titleRegister}
           className={styles.titleInput}

--- a/src/app/list/create/_components/StepOne.tsx
+++ b/src/app/list/create/_components/StepOne.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useQuery } from '@tanstack/react-query';
 
@@ -31,6 +31,7 @@ interface StepOneProps {
 export default function StepOne({ onNextClick, type }: StepOneProps) {
   const { language } = useLanguage();
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   /** 데이터 가져오기 */
   //--- 카테고리 가져오기
@@ -65,9 +66,21 @@ export default function StepOne({ onNextClick, type }: StepOneProps) {
   useEffect(() => {
     //카테고리 규칙 추가
     register('category', listCategoryRules);
-    //페이지 로드 시  'title', 'category'필 드 유효성 검사 강제 실행
+    //페이지 로드 시  'title', 'category'필드 유효성 검사 강제 실행
     trigger(['title', 'category']);
   }, [trigger, register, watchTitle]);
+
+  useEffect(() => {
+    //---주소에서 title, category 가져오기
+    const title = searchParams?.get('title');
+    const category = searchParams?.get('category');
+    /**TODO: 리스트 상세 '이 타이틀로 리스트 생성에도 encode단계 넣어주기 */
+
+    if (title) setValue('title', title);
+    if (category) {
+      setValue('category', categories?.find((c) => c.korName === category)?.engName);
+    }
+  }, [searchParams, categories]);
 
   return (
     <div className={styles.page}>

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -41,7 +41,9 @@ export default function TopicPage() {
   });
 
   const handleTopicClick = (topic: TopicType) => {
-    router.push(`/list/create?title=${topic.title}&category=${topic.categoryKorName}`);
+    const encodedTitle = encodeURIComponent(topic.title);
+    const encodedCategory = encodeURIComponent(topic.categoryKorName);
+    router.push(`/list/create?title=${encodedTitle}&category=${encodedCategory}`);
   };
 
   const handleBottomSheetClose = () => {


### PR DESCRIPTION
## 개요
- 리스트 생성, 수정의 오류를 수정했습니다.

<br>

## 작업 사항
- [x] Step2 순위 뱃지 줄바뀜, 제목 부분 가로폭 줄어들지 않고 화면 밖으로 튀어나가는 현상 -> css 조정으로 해결
    - flexGrow: 1 - 부모 컨테이너 사이즈에 따라 남는 공간 차지하도록 함
    - flexShrink: 0 -부모 컨테이너가 줄어드는 것에 따라 줄어들지 않도록 함
    - minWidth: 0 - 최소 너비를 설정하지 않으면 내용만큼은 사이즈가 유지 됨. 따라서 최소 너비를 0으로 설정하여 부모 컨테이너가 줄어들면 내용보다도 가로폭이 줄어들 수 있도록 함.
- [x] Step2 아이템 타이틀 밑 hr의 색상 적용되지 않음 -> stroke에 바로 색을 줄 수 없음. 선을 없애고 height를 주고 background-color에 색을 주기
- [x] 요청 주제 클릭하여 리스트 생성으로 넘어가는 경우, 타이틀과 카테고리가 자동으로 입력되지 않음 -> title, category 쿼리에서 받아와 입력하는 과정 추가
- [x] (쿼리에서 받아 입력할 때) 카테고리의 &를 텍스트로 인식 못함 (ex. '취미&레저'에서 '취미'만 가져와서 카테고리가 선택되지 않음) -> 인코딩된 텍스트가 쿼리로 입력되게 수정
- [x] 리스트 수정에서 태그 수정이 되지 않고, 게시 버튼이 작동하지 않음 -> useEffect의 의존성 배열에서 무한루프 문제가 발생한 것으로 보여서 수정했습니다. 잘 해결됐는지 여부는 머지 이후 dev-listywave에서 확인 필요합니다.

<br>

## 참고 사항 (optional)
- '이 타이틀로 리스트생성'하기에도 인코딩 과정을 넣어야하는데, 현지님과 충돌이 날까봐 우선 작업하지 않았습니다. 추후 작업하겠습니다! @kanglocal 
- 홈화면 주제 요청 제목 클릭시에 카테고리가 전달되지 않습니다. 아예 데이터가 없어서, api 수정 후 데이터를 받아올 수 있을 때 추가 작업하겠습니다! @kdkdhoho @Nahyun-Kang 

<br>

## 관련 이슈 (optional)

<br>

## 리뷰어에게

- 문제 발견해 주셔서 감사드립니다!🙇‍♀️ @kdkdhoho @Eugene-A-01 @ParkSohyunee 
